### PR TITLE
Clarify merge dialog primary/secondary and harden party utilities & child-table handling

### DIFF
--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
@@ -157,12 +157,12 @@ class DataQualityDashboard {
 
             // Bind button events
             card.find('.btn-dismiss').on('click', (e) => {
-                const $btn = $(e.target);
+                const $btn = $(e.currentTarget);
                 this.dismiss_duplicate($btn.data('party1'), $btn.data('party2'));
             });
 
             card.find('.btn-merge').on('click', (e) => {
-                const $btn = $(e.target);
+                const $btn = $(e.currentTarget);
                 this.show_merge_dialog($btn.data('party1'), $btn.data('party2'));
             });
 
@@ -237,6 +237,14 @@ class DataQualityDashboard {
     }
 
     show_merge_dialog(party1, party2) {
+        if (!party1 || !party2) {
+            frappe.msgprint(__('Unable to resolve the selected parties. Please refresh and try again.'));
+            return;
+        }
+        if (party1 === party2) {
+            frappe.msgprint(__('Cannot merge a party with itself.'));
+            return;
+        }
         const d = new frappe.ui.Dialog({
             title: __('Merge Parties'),
             fields: [
@@ -246,7 +254,19 @@ class DataQualityDashboard {
                     label: __('Keep (Primary Party)'),
                     options: [party1, party2].join('\n'),
                     default: party1,
-                    reqd: 1
+                    reqd: 1,
+                    onchange: () => {
+                        const primary = d.get_value('primary_party');
+                        const secondary = primary === party1 ? party2 : party1;
+                        d.set_value('secondary_party', secondary);
+                    }
+                },
+                {
+                    fieldname: 'secondary_party',
+                    fieldtype: 'Data',
+                    label: __('Merge (Secondary Party)'),
+                    read_only: 1,
+                    default: party2
                 },
                 {
                     fieldname: 'info',
@@ -259,7 +279,7 @@ class DataQualityDashboard {
             primary_action_label: __('Merge'),
             primary_action: (values) => {
                 const primary = values.primary_party;
-                const secondary = primary === party1 ? party2 : party1;
+                const secondary = values.secondary_party || (primary === party1 ? party2 : party1);
 
                 frappe.confirm(
                     __('Are you sure you want to merge {0} into {1}? This action cannot be undone.', [secondary, primary]),

--- a/uph/public/js/utils/party.js
+++ b/uph/public/js/utils/party.js
@@ -163,6 +163,31 @@ uph.party = {
 			},
 		});
 	},
+	get_child_table_fieldname: function (frm, child_doctype) {
+		if (frm.pm_on_child_fieldname) {
+			return frm.pm_on_child_fieldname;
+		}
+		const child_field = frm.meta.fields.find(
+			(df) => df.fieldtype === "Table" && df.options === child_doctype,
+		);
+		return child_field ? child_field.fieldname : null;
+	},
+	get_party_master_from_child: function (frm) {
+		const child_table = frm.pm_on_child_fieldname;
+		if (!child_table || !frm.fields_dict?.[child_table]?.grid) {
+			return null;
+		}
+
+		const grid = frm.fields_dict[child_table].grid;
+		const selected =
+			typeof grid.get_selected_children === "function" ? grid.get_selected_children() : [];
+		const rows = selected?.length ? selected : frm.doc[child_table] || [];
+		const row = rows.find((r) => r.party_master);
+		return row ? row.party_master : null;
+	},
+	get_party_master_for_history: function (frm) {
+		return frm.doc.party_master || this.get_party_master_from_child(frm);
+	},
 
 
 	// ✅ NEW: Create party from tree node (fetches doc then calls dialog)
@@ -865,16 +890,30 @@ uph.party = {
 	},
 
 	add_party_master_history_shortcut: function (frm) {
+		if (frm.__pm_history_shortcut_registered) {
+			return;
+		}
+		frm.__pm_history_shortcut_registered = true;
+		const resolve_frm = () => (cur_frm && cur_frm.doc ? cur_frm : frm);
 		const shortcut_action = () => {
+			const active_frm = resolve_frm();
+			const party_master = this.get_party_master_for_history(active_frm);
+			if (!party_master) {
+				frappe.msgprint(__("Please set a Party Master first."));
+				return;
+			}
 			console.log("[UPH] Executing History Shortcut Action");
-			this.show_party_master_history_dialog(frm);
+			this.show_party_master_history_dialog(active_frm, party_master);
 		};
 
 		const condition = () => {
-			const has_pm = !!frm.doc.party_master;
+			if (!cur_frm || cur_frm.doc?.name !== frm.doc?.name) {
+				return false;
+			}
+			const has_pm = !!this.get_party_master_for_history(cur_frm);
 			console.log("[UPH] History shortcut condition checked, result:", has_pm);
 			return has_pm;
-		}
+		};
 
 		// Main Shortcut (User Requested)
 		frappe.ui.keys.add_shortcut({
@@ -904,8 +943,12 @@ uph.party = {
 		});
 	},
 
-	show_party_master_history_dialog: function (frm) {
-		const party_master = frm.doc.party_master;
+	show_party_master_history_dialog: function (frm, party_master_override) {
+		const party_master = party_master_override || frm.doc.party_master;
+		if (!party_master) {
+			frappe.msgprint(__("Please set a Party Master first."));
+			return;
+		}
 		frappe.call({
 			method: "uph.party.controllers.queries.get_party_master_history_stats",
 			args: { party_master: party_master },

--- a/uph/public/js/utils/utils.js
+++ b/uph/public/js/utils/utils.js
@@ -249,10 +249,13 @@ $(document).on("app_ready", function () {
 				frappe.ui.form.on(child, {
 					party_master: function (frm, cdt, cdn) {
 						let row = locals[cdt][cdn];
+						const child_fieldname = uph.party.get_child_table_fieldname(frm, child);
 
 						if (!row.party_master) {
 							frappe.model.set_value(cdt, cdn, fieldname, "");
-							frm.refresh_field(frm.pm_on_child_fieldname);
+							if (child_fieldname) {
+								frm.refresh_field(child_fieldname);
+							}
 							return;
 						}
 
@@ -264,13 +267,21 @@ $(document).on("app_ready", function () {
 								// Set returned values from dialog
 
 								if (values) {
-									let grid = frm.fields_dict[frm.pm_on_child_fieldname].grid;
+									const update_steps = [];
+									const has_party_type = frappe.meta.has_field(cdt, "party_type");
 
-									if (grid.get_field("party_type")) {
-										frappe.model.set_value(cdt, cdn, "party_type", values.party_type);
+									if (has_party_type && values.party_type) {
+										update_steps.push(() =>
+											frappe.model.set_value(cdt, cdn, "party_type", values.party_type),
+										);
 									}
-									frappe.model.set_value(cdt, cdn, fieldname, values.party || values.name);
-									frm.refresh_field(frm.pm_on_child_fieldname);
+									update_steps.push(() =>
+										frappe.model.set_value(cdt, cdn, fieldname, values.party || values.name),
+									);
+									if (child_fieldname) {
+										update_steps.push(() => frm.refresh_field(child_fieldname));
+									}
+									frappe.run_serially(update_steps);
 								}
 							},
 						);


### PR DESCRIPTION
### Motivation
- Ensure the Merge dialog clearly shows which Party Master will be kept versus merged and make the selected primary party drive the secondary (old) value in the dialog.
- Prevent merge attempts when party ids cannot be resolved or when the same party would be merged into itself.
- Make Party Master history and child-table party selection more robust by resolving Party Master values from child rows and avoiding duplicate shortcut registrations or incorrect child-field refreshes.

### Description
- Update `uph/party/page/data_quality_dashboard/data_quality_dashboard.js` to use `e.currentTarget` for `.btn-dismiss` and `.btn-merge` handlers, add guards for missing/identical parties, add an explicit read-only `secondary_party` field, keep it in sync in `primary_party`'s `onchange`, and prefer the dialog `secondary_party` value when confirming the merge. 
- Add `get_child_table_fieldname`, `get_party_master_from_child`, and `get_party_master_for_history` to `uph/public/js/utils/party.js`, and update `add_party_master_history_shortcut` to avoid duplicate registrations, resolve the active `frm` at runtime, scope the shortcut condition to the active form, and pass an override `party_master` to `show_party_master_history_dialog`. 
- Change `show_party_master_history_dialog` to accept a `party_master_override` and validate presence of a Party Master before calling the backend. 
- Update child-table handling in `uph/public/js/utils/utils.js` to compute the child table fieldname via `get_child_table_fieldname`, check for `party_type` existence using `frappe.meta.has_field`, serialize `frappe.model.set_value` calls with `frappe.run_serially`, and refresh the computed child grid field rather than a hardcoded fieldname.

### Testing
- No automated tests were executed for these UI/JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a6a59a3d0832bb248cd4d8205df38)