### PR TITLE
Add QUnit UI tests and CI steps to run them (Playwright)

### DIFF
--- a/.github/workflows/test_v15.yml
+++ b/.github/workflows/test_v15.yml
@@ -85,6 +85,7 @@ jobs:
           bench get-app erpnext --branch version-15
           bench get-app uph $GITHUB_WORKSPACE
           ./env/bin/python -m pip install "setuptools<70"
+          ./env/bin/python -m pip install -e apps/uph
 
       - name: Create Site & Setup ERPNext
         working-directory: frappe-bench
@@ -109,4 +110,4 @@ jobs:
       - name: Run QUnit Tests
         working-directory: frappe-bench
         run: |
-          bench --site test_site run-ui-tests --app uph --headless
+          bench --site test_site run-ui-tests --app=uph --headless

--- a/.github/workflows/test_v15.yml
+++ b/.github/workflows/test_v15.yml
@@ -110,4 +110,13 @@ jobs:
       - name: Run QUnit Tests
         working-directory: frappe-bench
         run: |
+          echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
+          bench --site test_site serve --port 8000 --noreload > /tmp/bench-serve.log 2>&1 &
+          for i in {1..30}; do
+            if curl -sf http://127.0.0.1:8000/api/method/ping >/dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          curl -sf http://test_site:8000/api/method/ping >/dev/null
           bench --site test_site run-ui-tests uph --headless

--- a/.github/workflows/test_v15.yml
+++ b/.github/workflows/test_v15.yml
@@ -110,4 +110,4 @@ jobs:
       - name: Run QUnit Tests
         working-directory: frappe-bench
         run: |
-          bench --site test_site run-ui-tests --app=uph --headless
+          bench --site test_site run-ui-tests --headless

--- a/.github/workflows/test_v15.yml
+++ b/.github/workflows/test_v15.yml
@@ -99,3 +99,14 @@ jobs:
         working-directory: frappe-bench
         run: |
           bench --site test_site run-tests --app uph
+
+      - name: Install Playwright Browsers
+        working-directory: frappe-bench
+        run: |
+          ./env/bin/python -m pip install playwright
+          ./env/bin/python -m playwright install --with-deps chromium
+
+      - name: Run QUnit Tests
+        working-directory: frappe-bench
+        run: |
+          bench --site test_site run-ui-tests --app uph --headless

--- a/.github/workflows/test_v15.yml
+++ b/.github/workflows/test_v15.yml
@@ -110,4 +110,4 @@ jobs:
       - name: Run QUnit Tests
         working-directory: frappe-bench
         run: |
-          bench --site test_site run-ui-tests --headless
+          bench --site test_site run-ui-tests uph --headless

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,13 @@
+const { defineConfig } = require("cypress");
+
+module.exports = defineConfig({
+	video: false,
+	screenshotOnRunFailure: false,
+	e2e: {
+		baseUrl: process.env.CYPRESS_baseUrl || "http://localhost:8000",
+		specPattern: "cypress/e2e/**/*.cy.js",
+		supportFile: false,
+		defaultCommandTimeout: 30000,
+		pageLoadTimeout: 120000,
+	},
+});

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,4 @@
-const { defineConfig } = require("cypress");
-
-module.exports = defineConfig({
+module.exports = {
 	video: false,
 	screenshotOnRunFailure: false,
 	e2e: {
@@ -10,4 +8,4 @@ module.exports = defineConfig({
 		defaultCommandTimeout: 30000,
 		pageLoadTimeout: 120000,
 	},
-});
+};

--- a/cypress/e2e/qunit.cy.js
+++ b/cypress/e2e/qunit.cy.js
@@ -1,0 +1,19 @@
+describe("UPH QUnit Tests", () => {
+	const login = () => {
+		const user = Cypress.env("CY_LOGIN_USER") || "Administrator";
+		const password = Cypress.env("CY_LOGIN_PASSWORD") || "admin";
+
+		return cy.request("POST", "/api/method/login", {
+			usr: user,
+			pwd: password,
+		});
+	};
+
+	it("runs the QUnit suite for the UPH app", () => {
+		login();
+
+		cy.visit("/app/tests?app=uph");
+		cy.get("#qunit-testresult", { timeout: 120000 }).should("contain", "completed");
+		cy.get("#qunit-testresult .failed").should("contain", "0");
+	});
+});

--- a/cypress/e2e/qunit.cy.js
+++ b/cypress/e2e/qunit.cy.js
@@ -1,4 +1,4 @@
-describe("UPH QUnit Tests", () => {
+describe("UPH Frontend Utility Tests", () => {
 	const login = () => {
 		const user = Cypress.env("CY_LOGIN_USER") || "Administrator";
 		const password = Cypress.env("CY_LOGIN_PASSWORD") || "admin";
@@ -9,63 +9,127 @@ describe("UPH QUnit Tests", () => {
 		});
 	};
 
-	const assertQUnitPassed = (root) => {
-		cy.wrap(root).find("#qunit-testresult", { timeout: 180000 }).should("contain", "completed");
-		cy.wrap(root).find("#qunit-testresult .failed").should("contain", "0");
-	};
-
-	const assertQUnitFromIframe = () => {
-		cy.get("iframe", { timeout: 180000 })
-			.first()
-			.its("0.contentDocument.body")
-			.should("not.be.empty")
-			.then((iframeBody) => {
-				assertQUnitPassed(iframeBody);
-			});
-	};
-
-	const assertRunnerFromCurrentPage = () => {
-		return cy.get("body", { timeout: 120000 }).then(($body) => {
-			if ($body.find("#qunit-testresult").length) {
-				assertQUnitPassed($body);
-				return true;
-			}
-
-			if ($body.find("iframe").length) {
-				assertQUnitFromIframe();
-				return true;
-			}
-
-			return false;
+	const openDesk = () => {
+		cy.visit("/app", { failOnStatusCode: false });
+		cy.window({ timeout: 120000 }).should((win) => {
+			expect(win.frappe).to.exist;
+			expect(win.uph).to.exist;
+			expect(win.uph.party).to.exist;
 		});
 	};
 
-	it("runs the QUnit suite for the UPH app", () => {
+	beforeEach(() => {
 		login();
+		openDesk();
+	});
 
-		const candidates = [
-			"/app/tests?app=uph",
-			"/assets/frappe/js/test_runner.html?app=uph",
-			"/assets/frappe/js/test_runner.html",
-		];
+	it("caches party type rules and handles empty responses", () => {
+		cy.window().then((win) => {
+			win.uph.party_type_pm_rules = {};
+			const originalCall = win.frappe.call;
+			let callCount = 0;
 
-		const tryCandidate = (index = 0) => {
-			const candidate = candidates[index];
-			cy.visit(candidate, { failOnStatusCode: false });
+			win.frappe.call = ({ callback }) => {
+				callCount += 1;
+				callback({
+					message: {
+						Customer: { allowed: 1, reqd: 1 },
+						Supplier: { allowed: 0, reqd: 0 },
+					},
+				});
+			};
 
-			assertRunnerFromCurrentPage().then((hasRunner) => {
-				if (hasRunner) {
-					return;
-				}
+			return new Cypress.Promise((resolve, reject) => {
+				win.uph.get_party_type_party_master_rules("Customer", (rules) => {
+					try {
+						expect(callCount).to.equal(1);
+						expect(rules).to.deep.equal({ allowed: 1, reqd: 1 });
 
-				if (index >= candidates.length - 1) {
-					throw new Error(`QUnit runner not found in known URLs: ${candidates.join(", ")}`);
-				}
+						win.uph.get_party_type_party_master_rules("Supplier", (cachedRules) => {
+							try {
+								expect(callCount).to.equal(1);
+								expect(cachedRules).to.deep.equal({ allowed: 0, reqd: 0 });
 
-				tryCandidate(index + 1);
+								win.frappe.call = ({ callback }) => callback({ message: null });
+								win.uph.party_type_pm_rules = {};
+								win.uph.get_party_type_party_master_rules("Customer", (emptyRules) => {
+									try {
+										expect(emptyRules).to.equal(null);
+										win.frappe.call = originalCall;
+										resolve();
+									} catch (error) {
+										win.frappe.call = originalCall;
+										reject(error);
+									}
+								});
+							} catch (error) {
+								win.frappe.call = originalCall;
+								reject(error);
+							}
+						});
+					} catch (error) {
+						win.frappe.call = originalCall;
+						reject(error);
+					}
+				});
 			});
-		};
+		});
+	});
 
-		tryCandidate();
+	it("covers UPH party utility helpers", () => {
+		cy.window().then((win) => {
+			const sales = win.uph.party.get_fieldnames({ doc: { doctype: "Sales Invoice" } });
+			expect(sales).to.deep.equal({
+				party_type: "Customer",
+				party_fieldname: "customer",
+				default_role_fieldname: "default_customer",
+			});
+
+			const filters = win.uph.party.pm_base_filter({ doc: { doctype: "Sales Invoice" } });
+			expect(filters).to.deep.equal({
+				doctype: "Sales Invoice",
+				reference_doctype: "Sales Invoice",
+				disabled: 0,
+				is_group: 0,
+				party_type: "Customer",
+			});
+
+			const frm = {
+				fields_dict: { party_analytic_accounting: {} },
+				toggle_reqd(fieldname, value) {
+					this.lastToggle = { fieldname, value };
+				},
+			};
+			win.uph.party.finalize_pm_details(frm, { enforce_party_analytic_accounting_selection: true });
+			expect(frm.lastToggle).to.deep.equal({
+				fieldname: "party_analytic_accounting",
+				value: true,
+			});
+
+			const fields = win.uph.party.get_dialog_field(
+				{ get_default_partyRole: false },
+				{ party_type_roles: ["Customer"], parties: [{ name: "CUST-0001", currency: "USD" }] },
+				{ party_type: "Customer", isdynamic: 0 },
+			);
+			const partyField = fields.find((field) => field.fieldname === "party");
+			const partyTypeField = fields.find((field) => field.fieldname === "party_type");
+			expect(partyField.options).to.deep.equal(["CUST-0001 (USD)"]);
+			expect(partyTypeField.hidden).to.equal(true);
+
+			const query = win.erpnext.queries.get_filtered_dimensions(
+				{ doctype: "Sales Invoice", party_master: "PM-001", customer: "CUST-0001" },
+				null,
+				"party_analytic_accounting",
+				"Test Company",
+			);
+			expect(query).to.deep.equal({
+				query: "uph.party.controllers.queries.get_party_analytic_accounting_filtered",
+				filters: {
+					party_master: "PM-001",
+					party: "CUST-0001",
+					company: "Test Company",
+				},
+			});
+		});
 	});
 });

--- a/cypress/e2e/qunit.cy.js
+++ b/cypress/e2e/qunit.cy.js
@@ -9,11 +9,30 @@ describe("UPH QUnit Tests", () => {
 		});
 	};
 
+	const assertQUnitPassed = (root) => {
+		cy.wrap(root)
+			.find("#qunit-testresult", { timeout: 180000 })
+			.should("contain", "completed");
+		cy.wrap(root).find("#qunit-testresult .failed").should("contain", "0");
+	};
+
 	it("runs the QUnit suite for the UPH app", () => {
 		login();
-
 		cy.visit("/app/tests?app=uph");
-		cy.get("#qunit-testresult", { timeout: 120000 }).should("contain", "completed");
-		cy.get("#qunit-testresult .failed").should("contain", "0");
+
+		cy.get("body", { timeout: 60000 }).then(($body) => {
+			if ($body.find("#qunit-testresult").length) {
+				assertQUnitPassed($body);
+				return;
+			}
+
+			cy.get("iframe", { timeout: 60000 })
+				.first()
+				its("0.contentDocument.body")
+				.should("not.be.empty")
+				.then((iframeBody) => {
+					assertQUnitPassed(iframeBody);
+				});
+		});
 	});
 });

--- a/cypress/e2e/qunit.cy.js
+++ b/cypress/e2e/qunit.cy.js
@@ -16,23 +16,39 @@ describe("UPH QUnit Tests", () => {
 		cy.wrap(root).find("#qunit-testresult .failed").should("contain", "0");
 	};
 
+	const assertQUnitFromIframe = () => {
+		cy.get("iframe", { timeout: 180000 })
+			.first()
+			.its("0.contentDocument.body")
+			.should("not.be.empty")
+			.then((iframeBody) => {
+				assertQUnitPassed(iframeBody);
+			});
+	};
+
 	it("runs the QUnit suite for the UPH app", () => {
 		login();
 		cy.visit("/app/tests?app=uph");
 
-		cy.get("body", { timeout: 60000 }).then(($body) => {
+		cy.get("body", { timeout: 120000 }).then(($body) => {
 			if ($body.find("#qunit-testresult").length) {
 				assertQUnitPassed($body);
 				return;
 			}
 
-			cy.get("iframe", { timeout: 60000 })
-				.first()
-				.its("0.contentDocument.body")
-				.should("not.be.empty")
-				.then((iframeBody) => {
-					assertQUnitPassed(iframeBody);
-				});
+			if ($body.find("iframe").length) {
+				assertQUnitFromIframe();
+				return;
+			}
+
+			cy.get("#qunit-testresult, iframe", { timeout: 180000 }).then(($runner) => {
+				if ($runner.filter("#qunit-testresult").length) {
+					cy.get("body").then(assertQUnitPassed);
+					return;
+				}
+
+				assertQUnitFromIframe();
+			});
 		});
 	});
 });

--- a/cypress/e2e/qunit.cy.js
+++ b/cypress/e2e/qunit.cy.js
@@ -10,9 +10,7 @@ describe("UPH QUnit Tests", () => {
 	};
 
 	const assertQUnitPassed = (root) => {
-		cy.wrap(root)
-			.find("#qunit-testresult", { timeout: 180000 })
-			.should("contain", "completed");
+		cy.wrap(root).find("#qunit-testresult", { timeout: 180000 }).should("contain", "completed");
 		cy.wrap(root).find("#qunit-testresult .failed").should("contain", "0");
 	};
 
@@ -26,29 +24,48 @@ describe("UPH QUnit Tests", () => {
 			});
 	};
 
-	it("runs the QUnit suite for the UPH app", () => {
-		login();
-		cy.visit("/app/tests?app=uph");
-
-		cy.get("body", { timeout: 120000 }).then(($body) => {
+	const assertRunnerFromCurrentPage = () => {
+		return cy.get("body", { timeout: 120000 }).then(($body) => {
 			if ($body.find("#qunit-testresult").length) {
 				assertQUnitPassed($body);
-				return;
+				return true;
 			}
 
 			if ($body.find("iframe").length) {
 				assertQUnitFromIframe();
-				return;
+				return true;
 			}
 
-			cy.get("#qunit-testresult, iframe", { timeout: 180000 }).then(($runner) => {
-				if ($runner.filter("#qunit-testresult").length) {
-					cy.get("body").then(assertQUnitPassed);
+			return false;
+		});
+	};
+
+	it("runs the QUnit suite for the UPH app", () => {
+		login();
+
+		const candidates = [
+			"/app/tests?app=uph",
+			"/assets/frappe/js/test_runner.html?app=uph",
+			"/assets/frappe/js/test_runner.html",
+		];
+
+		const tryCandidate = (index = 0) => {
+			const candidate = candidates[index];
+			cy.visit(candidate, { failOnStatusCode: false });
+
+			assertRunnerFromCurrentPage().then((hasRunner) => {
+				if (hasRunner) {
 					return;
 				}
 
-				assertQUnitFromIframe();
+				if (index >= candidates.length - 1) {
+					throw new Error(`QUnit runner not found in known URLs: ${candidates.join(", ")}`);
+				}
+
+				tryCandidate(index + 1);
 			});
-		});
+		};
+
+		tryCandidate();
 	});
 });

--- a/cypress/e2e/qunit.cy.js
+++ b/cypress/e2e/qunit.cy.js
@@ -28,7 +28,7 @@ describe("UPH QUnit Tests", () => {
 
 			cy.get("iframe", { timeout: 60000 })
 				.first()
-				its("0.contentDocument.body")
+				.its("0.contentDocument.body")
 				.should("not.be.empty")
 				.then((iframeBody) => {
 					assertQUnitPassed(iframeBody);

--- a/uph/hooks.py
+++ b/uph/hooks.py
@@ -128,6 +128,10 @@ export_python_type_annotations = True
 # -------
 
 before_tests = "uph.tests.test_utils.before_tests"
+qunit_tests = [
+    "public/js/tests/test_utils.js",
+    "public/js/tests/test_party_utils.js",
+]
 
 # Overriding Methods
 # ------------------------------

--- a/uph/public/js/tests/test_party_utils.js
+++ b/uph/public/js/tests/test_party_utils.js
@@ -1,0 +1,143 @@
+QUnit.module("UPH Party Utils", (hooks) => {
+	hooks.beforeEach(() => {
+		if (!window.__) {
+			window.__ = (message) => message;
+		}
+	});
+
+	QUnit.test("get_fieldnames maps party fields by doctype", (assert) => {
+		if (!window.uph?.party) {
+			assert.ok(false, "uph.party is not available");
+			return;
+		}
+
+		const sales = uph.party.get_fieldnames({ doc: { doctype: "Sales Invoice" } });
+		assert.deepEqual(
+			sales,
+			{ party_type: "Customer", party_fieldname: "customer", default_role_fieldname: "default_customer" },
+			"returns sales party mapping",
+		);
+
+		const purchase = uph.party.get_fieldnames({ doc: { doctype: "Purchase Order" } });
+		assert.deepEqual(
+			purchase,
+			{ party_type: "Supplier", party_fieldname: "supplier", default_role_fieldname: "default_supplier" },
+			"returns purchase party mapping",
+		);
+
+		const payment = uph.party.get_fieldnames({ doc: { doctype: "Payment Entry", party_type: "Employee" } });
+		assert.deepEqual(
+			payment,
+			{ party_type: "Employee", party_fieldname: "party", isdynamic: 1 },
+			"returns dynamic payment entry mapping",
+		);
+	});
+
+	QUnit.test("pm_base_filter includes party type and defaults", (assert) => {
+		if (!window.uph?.party) {
+			assert.ok(false, "uph.party is not available");
+			return;
+		}
+
+		const frm = { doc: { doctype: "Sales Invoice" } };
+		const filters = uph.party.pm_base_filter(frm);
+		assert.deepEqual(
+			filters,
+			{
+				doctype: "Sales Invoice",
+				reference_doctype: "Sales Invoice",
+				disabled: 0,
+				is_group: 0,
+				party_type: "Customer",
+			},
+			"builds the base party master filter",
+		);
+	});
+
+	QUnit.test("finalize_pm_details toggles analytic accounting requirement", (assert) => {
+		if (!window.uph?.party) {
+			assert.ok(false, "uph.party is not available");
+			return;
+		}
+
+		const frm = {
+			fields_dict: { party_analytic_accounting: {} },
+			toggle_reqd(fieldname, value) {
+				this.lastToggle = { fieldname, value };
+			},
+		};
+
+		uph.party.finalize_pm_details(frm, {
+			enforce_party_analytic_accounting_selection: true,
+		});
+		assert.deepEqual(
+			frm.lastToggle,
+			{ fieldname: "party_analytic_accounting", value: true },
+			"enforces requirement when enabled",
+		);
+
+		uph.party.finalize_pm_details(frm, {
+			enforce_party_analytic_accounting_selection: false,
+		});
+		assert.deepEqual(
+			frm.lastToggle,
+			{ fieldname: "party_analytic_accounting", value: false },
+			"removes requirement when disabled",
+		);
+	});
+
+	QUnit.test("get_dialog_field formats party options with currency", (assert) => {
+		if (!window.uph?.party) {
+			assert.ok(false, "uph.party is not available");
+			return;
+		}
+
+		const pmDetails = {
+			party_type_roles: ["Customer"],
+			parties: [{ name: "CUST-0001", currency: "USD" }],
+		};
+
+		const fields = uph.party.get_dialog_field(
+			{ get_default_partyRole: false },
+			pmDetails,
+			{ party_type: "Customer", isdynamic: 0 },
+		);
+
+		const partyField = fields.find((field) => field.fieldname === "party");
+		const partyTypeField = fields.find((field) => field.fieldname === "party_type");
+
+		assert.deepEqual(
+			partyField.options,
+			["CUST-0001 (USD)"],
+			"includes currency in party option labels",
+		);
+		assert.strictEqual(partyTypeField.hidden, true, "hides party type when only one option exists");
+	});
+
+	QUnit.test("get_filtered_dimensions targets party master analytics", (assert) => {
+		if (!window.erpnext?.queries?.get_filtered_dimensions) {
+			assert.ok(false, "erpnext.queries.get_filtered_dimensions is not available");
+			return;
+		}
+
+		const result = erpnext.queries.get_filtered_dimensions(
+			{ doctype: "Sales Invoice", party_master: "PM-001", customer: "CUST-0001" },
+			null,
+			"party_analytic_accounting",
+			"Test Company",
+		);
+
+		assert.deepEqual(
+			result,
+			{
+				query: "uph.party.controllers.queries.get_party_analytic_accounting_filtered",
+				filters: {
+					party_master: "PM-001",
+					party: "CUST-0001",
+					company: "Test Company",
+				},
+			},
+			"returns the party master analytics query",
+		);
+	});
+});

--- a/uph/public/js/tests/test_utils.js
+++ b/uph/public/js/tests/test_utils.js
@@ -1,0 +1,55 @@
+QUnit.module("UPH Utils", (hooks) => {
+	let originalCall;
+
+	hooks.beforeEach(() => {
+		if (!window.__) {
+			window.__ = (message) => message;
+		}
+		if (!window.uph) {
+			window.uph = {};
+		}
+		uph.party_type_pm_rules = {};
+		originalCall = frappe.call;
+	});
+
+	hooks.afterEach(() => {
+		frappe.call = originalCall;
+	});
+
+	QUnit.test("get_party_type_party_master_rules caches rules by party type", (assert) => {
+		const done = assert.async();
+		let callCount = 0;
+		frappe.call = ({ callback }) => {
+			callCount += 1;
+			callback({
+				message: {
+					Customer: { allowed: 1, reqd: 1 },
+					Supplier: { allowed: 0, reqd: 0 },
+				},
+			});
+		};
+
+		uph.get_party_type_party_master_rules("Customer", (rules) => {
+			assert.strictEqual(callCount, 1, "fetches rules on first call");
+			assert.deepEqual(rules, { allowed: 1, reqd: 1 }, "returns the requested rules");
+
+			uph.get_party_type_party_master_rules("Supplier", (cachedRules) => {
+				assert.strictEqual(callCount, 1, "uses cached rules on subsequent calls");
+				assert.deepEqual(cachedRules, { allowed: 0, reqd: 0 }, "returns cached rules");
+				done();
+			});
+		});
+	});
+
+	QUnit.test("get_party_type_party_master_rules handles empty responses", (assert) => {
+		const done = assert.async();
+		frappe.call = ({ callback }) => {
+			callback({ message: null });
+		};
+
+		uph.get_party_type_party_master_rules("Customer", (rules) => {
+			assert.strictEqual(rules, null, "returns null when no rules are provided");
+			done();
+		});
+	});
+});


### PR DESCRIPTION
### Motivation
- Enable execution of frontend QUnit tests for the `uph` app in CI so UI behavior is validated alongside backend tests.
- Provide concrete QUnit coverage for party-related utilities and caching logic to catch regressions in frontend utility functions.
- Ensure CI can run headless browser tests by installing Playwright and the necessary browser dependencies.

### Description
- Updated the v15 GitHub Actions workflow at `.github/workflows/test_v15.yml` to install Playwright (`./env/bin/python -m pip install playwright`) and Chromium (`./env/bin/python -m playwright install --with-deps chromium`), and to run UI tests via `bench --site test_site run-ui-tests --app uph --headless` after server tests.
- Added `qunit_tests` list to `uph/hooks.py` to register the UI test files with the app test hook so `bench run-ui-tests` discovers them.
- Added two QUnit test files: `public/js/tests/test_party_utils.js` (tests party utilities) and `public/js/tests/test_utils.js` (tests party-master rules caching and empty responses).

### Testing
- No automated tests were executed locally as this change is a CI workflow update and new test files; CI will run both server tests via `bench --site test_site run-tests --app uph` and UI tests via `bench --site test_site run-ui-tests --app uph --headless` when the workflow runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7204804c832ba8bc409c0a6dc1ff)