### PR TITLE
Enforce party default currency when selecting party accounts

### DIFF
--- a/uph/party/controllers/party.py
+++ b/uph/party/controllers/party.py
@@ -713,8 +713,10 @@ def get_hierarchical_pm_account(pm_name, company, currency, enforce_strict=False
             as_dict=1,
         )
 
-        if not acc_data and not enforce_strict:
-            # 2. Try generic match (fallback) - Robust Python-based filtering
+        if not acc_data:
+            # 2. Try generic match (fallback row without currency).
+            # In strict mode this is still valid when the resolved account itself
+            # matches the requested currency (e.g. a group account expanded by currency).
             all_pm_accounts = frappe.db.get_values(
                 "Party Master Accounts",
                 {"parent": pm_name, "company": company},

--- a/uph/party/controllers/party.py
+++ b/uph/party/controllers/party.py
@@ -668,18 +668,31 @@ def get_party_details(
 
     # Hierarchical Account Lookup
     account_fieldname = "debit_to" if party_type == "Customer" else "credit_to"
-    if not party_details.get(account_fieldname):
-        transaction_currency = currency or party_details.get("currency")
-        if party_master and company and transaction_currency:
-            enforce_strict = settings.enforce_strict_currency
-            target_account = get_hierarchical_pm_account(
-                party_master,
-                company,
-                transaction_currency,
-                enforce_strict=enforce_strict,
-            )
-            if target_account:
-                party_details[account_fieldname] = target_account
+    party_default_currency = get_party_default_currency(party_type, party)
+    transaction_currency = currency or party_details.get("currency")
+    lookup_currency = transaction_currency
+    enforce_strict = settings.enforce_strict_currency
+    if enforce_strict and party_default_currency:
+        lookup_currency = party_default_currency
+
+    existing_account = party_details.get(account_fieldname)
+    if existing_account and enforce_strict and party_default_currency:
+        account_currency = frappe.db.get_value(
+            "Account", existing_account, "account_currency"
+        )
+        if account_currency and account_currency != party_default_currency:
+            existing_account = None
+            party_details[account_fieldname] = None
+
+    if not existing_account and party_master and company and lookup_currency:
+        target_account = get_hierarchical_pm_account(
+            party_master,
+            company,
+            lookup_currency,
+            enforce_strict=enforce_strict,
+        )
+        if target_account:
+            party_details[account_fieldname] = target_account
 
     return party_details
 
@@ -750,3 +763,10 @@ def get_hierarchical_pm_account(pm_name, company, currency, enforce_strict=False
         pm_name = frappe.db.get_value("Party Master", pm_name, "parent_party_master")
 
     return None
+
+
+def get_party_default_currency(party_type, party):
+    if not party or party_type not in ("Customer", "Supplier"):
+        return None
+
+    return frappe.db.get_value(party_type, party, "default_currency")

--- a/uph/tests/test_party_details_override.py
+++ b/uph/tests/test_party_details_override.py
@@ -267,3 +267,22 @@ class TestPartyDetailsOverride(FrappeTestCase):
             party=plain_customer.name, party_type="Customer", company=self.company
         )
         self.assertEqual(details.get("debit_to"), erp_details.get("debit_to"))
+
+    def test_strict_currency_uses_party_default_currency_account(self):
+        self.customer.reload()
+        self.customer.default_currency = self.currency_usd
+        self.customer.save(ignore_permissions=True)
+
+        settings = frappe.get_doc("Party Master Settings")
+        settings.enforce_strict_currency = 1
+        settings.save(ignore_permissions=True)
+        frappe.clear_cache(doctype="Party Master Settings")
+
+        details = uph_get_party_details(
+            party=self.customer.name,
+            party_type="Customer",
+            company=self.company,
+            currency=self.currency_sar,
+        )
+
+        self.assertEqual(details.get("debit_to"), self.acc_usd.name)


### PR DESCRIPTION
### Motivation
- Ensure account selection for a party respects the party's default currency when Party Master Settings enable strict currency enforcement so returned `debit_to`/`credit_to` align with party expectations.
- Prevent cases where ERPNext-provided or transaction currency-based accounts violate party-level currency rules and produce inconsistent account mapping.

### Description
- Update `get_party_details` to determine a `lookup_currency` that uses the party default currency when `Party Master Settings.enforce_strict_currency` is enabled, otherwise falling back to the transaction/document currency.
- If strict mode is enabled and an existing ERPNext-selected account's `account_currency` does not match the party default currency, clear that account and remap via the hierarchical Party Master account lookup. 
- Add helper `get_party_default_currency(party_type, party)` to centralize retrieving the party default currency for `Customer`/`Supplier` types.
- Add a regression test `test_strict_currency_uses_party_default_currency_account` to validate that strict mode returns the account matching the party default currency even when the transaction currency differs.

### Testing
- Ran `python -m compileall uph/party/controllers/party.py uph/tests/test_party_details_override.py`, which succeeded and compiled the modified files. 
- Attempted `pytest -q uph/tests/test_party_details_override.py -k strict_currency_uses_party_default_currency_account`, which could not run in this environment because the test runtime depends on `frappe` and the module is not available, so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb34dc874832bbc5809d85634a037)