### PR TITLE
docs: recreate UPH documentation from static analysis and add AI action buttons

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -61,6 +61,7 @@ body,
     color: #555;
 }
 
+
 .doc-ai-actions {
   display: flex;
   justify-content: flex-end;
@@ -73,12 +74,12 @@ body,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #d4d4d8;
-  background: #fff;
+  border: 1px solid #e4e4e7;
+  background: #fafafa;
   color: #27272a;
   border-radius: 999px;
-  padding: 0.35rem 0.8rem;
-  font-size: 0.85rem;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.82rem;
   font-weight: 600;
   text-decoration: none;
   transition: all 0.15s ease;
@@ -86,27 +87,16 @@ body,
 
 .doc-ai-btn:hover {
   border-color: #a1a1aa;
+  background: #ffffff;
   color: #111827;
   text-decoration: none;
 }
 
-.doc-ai-btn.chatgpt:hover {
-  border-color: #10a37f;
-  color: #0f766e;
-}
-
-.doc-ai-btn.gemini:hover {
-  border-color: #2563eb;
-  color: #1d4ed8;
-}
-
-.doc-ai-btn.claude:hover {
-  border-color: #9333ea;
-  color: #7e22ce;
-}
+.doc-ai-btn.chatgpt:hover { border-color: #10a37f; color: #0f766e; }
+.doc-ai-btn.gemini:hover { border-color: #2563eb; color: #1d4ed8; }
+.doc-ai-btn.claude:hover { border-color: #9333ea; color: #7e22ce; }
 
 @media (max-width: 768px) {
-  .doc-ai-actions {
-    justify-content: flex-start;
-  }
+  .doc-ai-actions { justify-content: flex-start; }
 }
+

--- a/content.en/docs/recreated/_index.md
+++ b/content.en/docs/recreated/_index.md
@@ -1,17 +1,25 @@
 ---
-title: "Recreated Documentation (From Source Analysis)"
+title: "Recreated Documentation (Static Code Analysis)"
 weight: 5
 bookCollapseSection: true
 ---
 
 # Recreated Documentation
 
-This section is regenerated from static analysis of the repository source (templates, configuration, and content structure), and is written as a consolidated user + developer guide.
+This section was rebuilt from static analysis of the UPH Python bytecode and the Hugo site source available in this repository.
 
-## Included Guides
+## Scope
 
-- [Product Introduction and Problem Statement](./introduction-and-problem.md)
-- [Architecture and Domain Model](./architecture-and-domain-model.md)
-- [Installation, Configuration, and Usage](./installation-configuration-usage.md)
-- [APIs, Hooks, Security, Extensibility, and Limitations](./api-hooks-security-extensibility.md)
+- Product purpose and domain model
+- Doctypes and business workflows
+- Hooks, APIs, and reports
+- Configuration and deployment
+- Security model and limitations
+- Extension guidance for developers
 
+## Documents
+
+1. [Introduction and Problem Space](./introduction-and-problem.md)
+2. [Architecture, Domain Model, and Workflows](./architecture-and-domain-model.md)
+3. [Installation, Setup, and Configuration](./installation-configuration-usage.md)
+4. [APIs, Hooks, Security, Extensibility, and Limitations](./api-hooks-security-extensibility.md)

--- a/content.en/docs/recreated/api-hooks-security-extensibility.md
+++ b/content.en/docs/recreated/api-hooks-security-extensibility.md
@@ -3,91 +3,99 @@ title: "APIs, Hooks, Security, Extensibility, and Limitations"
 weight: 4
 ---
 
-# API Reference (Source-Inferred)
+# API and callable surface (source-inferred)
 
-The repository references the following callable paths and integration surfaces:
+## Boot/session helpers
 
-## Party APIs
+- `uph.party.boot.add_pm_doctypes`
+- `uph.party.boot.get_pm_doctypes`
+- `uph.party.boot.get_party_master_depends_on_fields`
 
-- `uph.party.controllers.party.get_party_details`
-- `uph.party.controllers.party.set_party_master`
+## Party and query controllers
 
-## Data Quality APIs
+- `uph.party.controllers.queries.party_master_link_query`
+- `uph.party.controllers.queries.get_party_master`
+- `uph.party.doctype.party_master.party_master.create_party_master`
+- `uph.party.doctype.party_master.party_master.create_party_from_party_master`
+- `uph.party.doctype.party_master.party_master.map_party_to_target`
+- `uph.party.doctype.party_master.party_master.assign_party_master_for_selection`
+
+## Data quality / MDM controllers
 
 - `uph.party.controllers.mdm.normalize_text`
 - `uph.party.controllers.mdm.validate_document_quality`
-- `uph.party.page.data_quality_dashboard.get_potential_duplicates`
-- `uph.party.page.data_quality_dashboard.merge_parties`
-- `uph.party.page.data_quality_dashboard.dismiss_duplicate`
-- `uph.party.page.data_quality_dashboard.get_dashboard_stats`
 
-## Query API
+## Regional helper
 
-- `uph.party.controllers.queries.party_master_link_query`
+- `uph.regional.arabic.money_in_words`
 
-## Background Update Entry Points
+# Hooks and events
 
-- `uph.party.controllers.party.on_change_party_master_update_transactional_document_types`
-- `uph.party.controllers.mdm._update_party_master_references` (documented as representative background sync function)
+Hooks indicate:
 
-# Hooks and Background Jobs
+- app include JS bundle (`uph.bundle.js` + rule builder js)
+- treeview support for `Party Master`
+- boot hook for injecting Party Master metadata
+- document event handlers on validate/update/change/trash/before_validate for mapped doctypes
 
-## Hook Patterns (Documented)
+These events enforce role compatibility, required party master rules, and transactional consistency.
 
-- `validate`
-- `before_validate`
-- `on_update`
-- `on_trash`
+# Background jobs and heavy operations
 
-## Workflow Impact
+From controller behavior and constants, UPH supports large-scale update patterns:
 
-- Enforce linkage and quality controls at save-time.
-- Keep existing transactional records consistent after merge/relink events.
-- Offload large updates into long queue jobs.
+- recount linked-party totals,
+- update existing mapped transaction rows,
+- optional queued updates for changed party assignments,
+- cache invalidation after mapping/settings changes.
 
-# Permissions and Security Model (Inferred)
+# Caching model
 
-1. Access control is expected to remain aligned with Frappe role permissions on involved DocTypes.
-2. Whitelisted APIs should be treated as privileged business endpoints and protected by standard authentication/session controls.
-3. Merge actions imply audit and governance requirements; maintain role-restricted access.
-4. Bulk update jobs should be considered sensitive operations and scheduled on trusted queues.
+UPH uses Redis/local cache helpers for:
 
-# Integration Points
+- party type list,
+- party-master-to-party mappings,
+- role lists,
+- doctype field maps,
+- usage-based link-search acceleration.
 
-- ERPNext standard party masters (Customer/Supplier/Employee)
-- Transactional DocTypes with injected `party_master` link fields
-- Reports and dashboard pages
-- Bench deployment lifecycle (`install-app`, `migrate`, `build`)
+# Permissions and security model
 
-# Extensibility and Customization
+## What is visible in code
 
-## Supported Extension Approaches
+- Validation routines frequently bypass during patch/install/import contexts.
+- Settings operations include privileged checks (e.g., System Manager guardrails).
+- Duplicate actions are designed to warn/throw based on configured policy.
 
-- Add custom DocTypes to Party Master field-injection configuration.
-- Register custom hook handlers around party validation life cycle.
-- Extend normalization strategy for locale-specific data quality logic.
-- Build custom analytics from Party Master and Party Analytic Accounting linkage.
+## Operational guidance
 
-## Documentation UI Customization
+- Restrict Settings and merge-sensitive actions to governance/admin roles.
+- Treat whitelisted methods as authenticated business APIs.
+- Audit bulk reassignments and duplicate resolution actions.
 
-This repository now includes visible top-right actions per page to send context to:
+# Integration points
 
-- Ask ChatGPT
-- Ask Gemini
-- Ask Claude
+- ERPNext party doctypes (Customer, Supplier, Employee, Shareholder support inferred in mappings)
+- Sales/Purchase and accounting transactional doctypes
+- Frappe reports and dashboard components
+- Multi-currency account behavior and Arabic number-to-words localization
 
-The action prompt includes page title, URL, and page text excerpt.
+# Extensibility and customization
 
-# Known Limitations and Assumptions
+- Add new party doctypes via Party Master Settings mappings.
+- Extend duplicate detection by adding conditions/weights/check types.
+- Extend transaction propagation by defining additional mapped doctypes.
+- Build custom reports by reusing party-master and linked-party query helpers.
 
-1. This repository primarily contains documentation-site source; underlying Python app modules are not present here.
-2. Detailed code-level behavior beyond referenced API paths cannot be fully validated from this repository alone.
-3. URL-based prompt prefill support can vary by AI provider over time.
-4. Large pages are truncated before context transmission to avoid URL-size limits.
+# Known limitations and assumptions
 
-# Developer Notes
+1. The repository currently ships Python bytecode (`.pyc`) rather than editable `.py` source for app logic; this documentation is reconstructed from static bytecode inspection.
+2. Bytecode analysis reveals callable names, constants, and structure, but not all comments/type hints.
+3. External behavior still depends on runtime metadata, custom fields, and live ERPNext data.
+4. AI-assistant URL prefill support may vary by provider and browser.
 
-- Site is Hugo-based using the Book theme.
-- Menu and docs hierarchy are configuration-driven (`config.toml`) and content-structure-driven.
-- Custom layout overrides live under `layouts/` and custom styling under `assets/custom.css` / `static/custom.css`.
+# Developer notes
 
+- The docs site is Hugo-based (Book theme overrides in `layouts/`).
+- UPH-specific docs UI customizations are in custom layouts/partials and custom CSS.
+- For app code maintenance, restore tracked `.py` sources alongside `.pyc` artifacts to improve traceability and reviewability.

--- a/content.en/docs/recreated/architecture-and-domain-model.md
+++ b/content.en/docs/recreated/architecture-and-domain-model.md
@@ -1,94 +1,84 @@
 ---
-title: "Architecture and Domain Model"
+title: "Architecture, Domain Model, and Workflows"
 weight: 2
 ---
 
-# Architecture Overview
+# Architecture overview
 
-UPH is represented as a non-intrusive extension model around ERPNext party entities.
+UPH is implemented as a Frappe app (`uph`) with these primary layers:
 
-## High-Level Layers
+1. **Domain layer** (`party_master`, role child tables, party analytic accounting).
+2. **Controller layer** (`party.py`, `queries.py`, `mdm.py`, `field.py`).
+3. **Settings and schema orchestration** (`party_master_settings.py`).
+4. **Caching and boot helpers** (`uph.__init__`, `party.boot`).
+5. **Reporting layer** (party account statement/balances, chronological ledger, health report).
 
-1. **Domain Layer**
-   - Party Master (canonical identity)
-   - Party role links (Customer/Supplier/Employee)
-   - Relationship model (N:N and hierarchy)
+## Domain model (inferred from doctype modules)
 
-2. **Configuration Layer**
-   - Party Master Settings (single DocType pattern)
-   - Per-party-type uniqueness and behavior controls
-   - Dynamic field mapping/injection controls
-
-3. **Validation + Governance Layer**
-   - Duplicate detection and normalization
-   - Quality scoring and dashboard APIs
-   - Merge/dismiss workflows
-
-4. **Accounting/Reporting Layer**
-   - Party Analytic Accounting for segmented reporting
-   - Currency/account-aware mappings
-   - Consolidated statements and health metrics
-
-5. **Performance Layer**
-   - Smart cache utility pattern
-   - Query optimization and batched updates
-   - Background queue updates for bulk consistency tasks
-
-## Domain Model (Inferred from Source)
-
-### Primary Entities
+### Primary Doctypes
 
 - **Party Master**
-  - Root identity for legal entities
-  - Supports parent-child hierarchy
-  - Holds governance and role linkage metadata
+  - Tree/nested-set behavior, hierarchical numbering, lifecycle hooks.
+  - Child tables include roles and linked parties.
+
+- **Party Master Role**
+  - Defines allowed roles (`party_type_role`) for a Party Master.
 
 - **Party Master Parties**
-  - Child/junction model connecting Party Master to role records
-  - Dynamic link pattern for party type + party record
+  - Links Party Master to concrete party documents with `party_type`, `party`, `party_name`, `currency`.
 
 - **Party Master Settings**
-  - Single settings document controlling runtime behavior
-  - Contains party-type rules, DocType settings, and field mapping controls
+  - Governs target doctypes, mapping rules, required/allowed policies, and auto-creation of `party_master` fields.
+
+- **Data Quality Rule / Data Quality Rule Condition**
+  - Configures duplicate matching criteria (exact/fuzzy/date range), weights, similarity, and filter expressions.
 
 - **Party Analytic Accounting**
-  - Additional accounting dimension model
-  - Supports effective dates and allow/restrict style controls
+  - Assigns analytics to Party Master/parties with allow/restrict company controls and effective date windows.
 
-- **Party Relationship**
-  - N-to-N relationship mapping for ownership/corporate links
+### Key relationships
 
-### Secondary/Operational Entities
+- One Party Master can map to many party records across multiple roles.
+- A party record maps to one Party Master (enforced/validated by rules).
+- Transactional doctypes can carry an auto-managed `party_master` field.
 
-- Duplicate tracking and exclusion model
-- Dashboard aggregation models/views
-- Quality rule models for validation thresholds and matching rules
+## Business workflows
 
-## Business Workflows
+## 1) Party Master lifecycle
 
-### 1) Canonical Party Onboarding
+- Create Party Master with hierarchical constraints.
+- Validate role consistency.
+- Auto-generate numbering and maintain linked-party counters.
+- Create primary contact/address helpers.
 
-1. Create Party Master.
-2. Attach one or more operational roles.
-3. Apply uniqueness and data quality checks.
-4. Start using role records in transactions while preserving canonical linkage.
+## 2) Rule-based party linking
 
-### 2) Multi-Currency Operations
+- `validate_party_master_on_target_party_type` enforces required/allowed logic.
+- `validate_party_master_on_document_types` sets or validates `party_master` on mapped documents.
+- Duplicate checks prevent conflicting party-to-master assignments.
 
-1. Configure account/currency mappings in Party Master context.
-2. Use the same legal entity across role transactions.
-3. Resolve appropriate account path by transaction context.
+## 3) Transactional synchronization
 
-### 3) Duplicate Management
+When a party's master changes, UPH can:
 
-1. Run duplicate detection via dashboard API.
-2. Review scored candidates.
-3. Merge duplicates or dismiss false positives.
-4. Trigger reference update process to preserve transactional integrity.
+- scan configured doctypes,
+- count/update historical rows,
+- optionally run queued/background update flows,
+- leave audit comments on Party Master.
 
-### 4) Background Reference Synchronization
+## 4) Duplicate governance workflow
 
-1. Party linkage changes trigger update workflow.
-2. Background job updates configured transactional DocTypes.
-3. New documents continue to be auto-tagged by hooks.
+`mdm.validate_document_quality` loads active quality rules and:
 
+- evaluates optional filter conditions,
+- detects potential duplicates by weighted criteria,
+- triggers configured action (warn/block) with scored records.
+
+## 5) Reporting workflow
+
+Reports aggregate by Party Master and linked parties to produce:
+
+- chronological movement,
+- account balances,
+- statement with opening/current logic,
+- health metrics (linked vs unlinked records).

--- a/content.en/docs/recreated/installation-configuration-usage.md
+++ b/content.en/docs/recreated/installation-configuration-usage.md
@@ -1,88 +1,80 @@
 ---
-title: "Installation, Configuration, and Usage"
+title: "Installation, Setup, and Configuration"
 weight: 3
 ---
 
-# Installation & Setup
+# Installation and setup
 
 ## Prerequisites
 
-- Frappe/ERPNext deployment with bench tooling
-- Python runtime supported by your ERPNext version
-- MariaDB or PostgreSQL backend
+- ERPNext/Frappe environment with Bench
+- Installed dependency app: `erpnext` (required by hooks)
+- Site admin access
 
-## Installation Steps
+## Install
 
 ```bash
-bench get-app https://github.com/Sendipad/uph
-bench --site <your-site> install-app uph
-bench --site <your-site> migrate
+bench get-app <uph-repository-url>
+bench --site <site-name> install-app uph
+bench --site <site-name> migrate
 bench build --app uph
 bench restart
 ```
 
-## Initial Validation Checklist
+## Post-install initialization
 
-- Party workspace is visible
-- Party Master Settings is available
-- Core reports load successfully
-- Data quality dashboard returns baseline metrics
+The app defines an `after_install` entrypoint and boot-time setup hooks. After install:
 
-# Configuration Guide
+1. Open **Party Master Settings**.
+2. Seed/validate party type table and document type mappings.
+3. Create/update custom `party_master` fields on configured doctypes.
+4. Confirm `party_master` appears in target forms.
 
-## Core Settings
+# Configuration reference
 
-Configure **Party Master Settings** first:
+## Party Master Settings
 
-- Enable target party types (Customer/Supplier/Employee)
-- Define uniqueness boundaries per role and currency
-- Configure duplicate handling behavior (warn/stop)
-- Set linked DocTypes that should receive `party_master`
+Main configuration areas inferred from the settings controller:
 
-## Data Governance Setup
+- **Party types rules** (`reqd`, `allowed`, `rule_fieldname`)
+- **Document type mappings**
+  - `document_type`
+  - `parent_doctype`
+  - `party_fieldname`
+  - `party_type_fieldname`
+  - dynamic-party-type behavior
+- **Party master fields** mapping table for source/target field sync
 
-- Define normalization and duplicate quality rules
-- Set score threshold and review policy
-- Add exclusion rules for known safe duplicates
+The settings controller validates field existence and can reject non-system-manager edits for sensitive operations.
 
-## Reporting Setup
+## Recommended rollout sequence
 
-- Enable Party Analytic Accounting if used
-- Configure default account/currency behavior
-- Validate consolidated reports with sample records
+1. Configure party-type rules.
+2. Configure transactional doctypes that need `party_master`.
+3. Sync custom fields.
+4. Backfill or relink existing records.
+5. Enable/adjust data quality rules.
+6. Validate with health and account reports.
 
-# Feature-by-Feature Usage
+# Usage examples
 
-## Unified Role Linking
+## Example A: Link existing parties
 
-Use Party Master as root and link Customer/Supplier/Employee records to maintain one legal-entity profile.
+1. Create Party Master `PM-ACME`.
+2. Add roles: Customer + Supplier.
+3. Assign existing Customer/Supplier records to `PM-ACME`.
+4. Save and verify linked count + report visibility.
 
-## Hierarchy Management
+## Example B: Auto-manage party master in transactions
 
-Create parent and child Party Masters for holding-company, regional, and branch-level structures.
+1. In settings, map `Sales Invoice` and `Purchase Invoice`.
+2. Ensure `party_fieldname` points to `customer`/`supplier`.
+3. Save mapping and regenerate fields.
+4. Create new transactions and verify `party_master` is set/validated.
 
-## Relationship Management
+## Example C: Data quality enforcement
 
-Capture non-tree relations (ownership, affiliate, subsidiary) via Party Relationship model.
-
-## Data Quality Dashboard
-
-Use the dashboard APIs/UI to:
-
-- monitor quality metrics,
-- review possible duplicates,
-- execute merges,
-- track dismissed candidates.
-
-## Reporting
-
-Use Party Master-centric reports for cross-role financial and operational visibility.
-
-# Usage Example (Operational)
-
-1. Create `PM-ACME` as a Party Master.
-2. Link existing Customer and Supplier records for Acme.
-3. Configure account mapping for USD/EUR context.
-4. Post sales and purchase transactions.
-5. Review consolidated statement and quality status.
-
+1. Create Data Quality Rule for Customer.
+2. Add conditions (Exact + Fuzzy match on name/phone/email).
+3. Set action to warn or block.
+4. Save a record and review duplicate alert behavior.

--- a/content.en/docs/recreated/introduction-and-problem.md
+++ b/content.en/docs/recreated/introduction-and-problem.md
@@ -1,43 +1,42 @@
 ---
-title: "Introduction and Problem Statement"
+title: "Introduction and Problem Space"
 weight: 1
 ---
 
 # Introduction
 
-Unified Party Hub (UPH) is positioned as a master data management layer for ERPNext/Frappe deployments where one legal entity can appear in multiple operational roles (Customer, Supplier, Employee).
+**Unified Party Hub (UPH)** is a Frappe/ERPNext app that introduces a canonical **Party Master** record and links operational party doctypes (Customer, Supplier, Employee, etc.) into a single governed identity layer.
 
-## What Problem UPH Solves
+## What problem UPH solves
 
-From repository source analysis, UPH addresses these operational gaps:
+From static analysis of `hooks`, controllers, and reports, UPH targets these ERP pain points:
 
-1. **Fragmented identity records** for the same legal entity across Customer/Supplier/Employee masters.
-2. **Multi-currency duplication pressure**, where teams create multiple party records to map different account/currency needs.
-3. **Weak relationship visibility** between parent companies, branches, and role variants.
-4. **Data quality drift** due to duplicate entries and inconsistent naming.
-5. **Reporting silos**, where financial views are split by party document type instead of legal entity.
+1. **Same legal entity spread across multiple party records**.
+2. **Weak cross-role visibility** (e.g., customer + supplier under one business).
+3. **No canonical hierarchy** for parent/child legal entities.
+4. **Duplicate and low-quality party data** entering the system.
+5. **Party-level reporting fragmentation** across role-specific doctypes.
 
-## Core Concept
+## Core concept
 
-UPH introduces a unifying canonical record called **Party Master** and links role-specific ERPNext records into that canonical layer.
+UPH introduces these concepts:
 
-- Party Master becomes the legal-entity anchor.
-- Role records remain usable (Customer/Supplier/Employee), but are normalized and linked.
-- Reporting and accounting contexts can be consolidated at Party Master level.
+- **Party Master** as the canonical legal entity node (tree/nested set).
+- **Role links** from Party Master to party doctypes.
+- **Rules** for allowed/required party mapping.
+- **Auto-propagation** of `party_master` into configured transactional doctypes.
+- **Data quality rules** with exact/fuzzy/date-window matching.
 
-## Intended Users
+## Typical users
 
+- ERP implementers and solution architects
 - Master data governance teams
-- ERP administrators and implementation consultants
-- Finance teams requiring party-level consolidated visibility
-- Developers integrating party identity across custom DocTypes
+- Finance teams requiring consolidated party reporting
+- Frappe developers extending party workflows
 
-## Documentation Scope
+## Terminology
 
-This recreated documentation is derived from:
-
-- Hugo documentation source and page taxonomy
-- Exposed API method paths listed in the repository
-- Theme/layout and custom UI logic
-- Feature declarations present in content and configuration files
-
+- **Party Master**: Canonical legal-entity record.
+- **Party Type**: Target ERP doctype role (Customer/Supplier/Employee).
+- **Transactional Doctype Mapping**: Config describing where `party_master` should be auto-managed.
+- **Data Quality Rule**: Matching policy used to detect potential duplicate records.

--- a/layouts/_partials/docs/ai-page-actions.html
+++ b/layouts/_partials/docs/ai-page-actions.html
@@ -2,59 +2,6 @@
 {{- $url := .Permalink -}}
 {{- $summary := .Summary | plainify -}}
 
-<style>
-  .doc-ai-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    margin: 0 0 1rem;
-    flex-wrap: wrap;
-  }
-
-  .doc-ai-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid #d4d4d8;
-    background: #fff;
-    color: #27272a;
-    border-radius: 999px;
-    padding: 0.35rem 0.8rem;
-    font-size: 0.85rem;
-    font-weight: 600;
-    text-decoration: none;
-    line-height: 1.2;
-    transition: all 0.15s ease;
-  }
-
-  .doc-ai-btn:hover {
-    border-color: #a1a1aa;
-    color: #111827;
-    text-decoration: none;
-  }
-
-  .doc-ai-btn.chatgpt:hover {
-    border-color: #10a37f;
-    color: #0f766e;
-  }
-
-  .doc-ai-btn.gemini:hover {
-    border-color: #2563eb;
-    color: #1d4ed8;
-  }
-
-  .doc-ai-btn.claude:hover {
-    border-color: #9333ea;
-    color: #7e22ce;
-  }
-
-  @media (max-width: 768px) {
-    .doc-ai-actions {
-      justify-content: flex-start;
-    }
-  }
-</style>
-
 <div class="doc-ai-actions" data-page-title="{{ $title | htmlEscape }}" data-page-url="{{ $url | safeURL }}" data-page-summary="{{ $summary | htmlEscape }}">
   <a class="doc-ai-btn chatgpt" href="#" data-ai="chatgpt" rel="noopener noreferrer" target="_blank">Ask ChatGPT</a>
   <a class="doc-ai-btn gemini" href="#" data-ai="gemini" rel="noopener noreferrer" target="_blank">Ask Gemini</a>
@@ -66,48 +13,47 @@
   const container = document.querySelector('.doc-ai-actions');
   if (!container) return;
 
-  function trimmed(text, maxLen) {
+  const providers = {
+    chatgpt: (prompt) => `https://chatgpt.com/?q=${encodeURIComponent(prompt)}`,
+    gemini: (prompt) => `https://gemini.google.com/app?prompt=${encodeURIComponent(prompt)}`,
+    claude: (prompt) => `https://claude.ai/new?q=${encodeURIComponent(prompt)}`
+  };
+
+  function trimText(text, maxLen) {
     if (!text) return '';
-    const clean = String(text).replace(/\s+/g, ' ').trim();
-    return clean.length > maxLen ? clean.slice(0, maxLen) + '…' : clean;
+    const cleaned = String(text).replace(/\s+/g, ' ').trim();
+    return cleaned.length > maxLen ? `${cleaned.slice(0, maxLen)}…` : cleaned;
   }
 
   function buildPrompt() {
     const title = container.dataset.pageTitle || document.title;
     const pageUrl = container.dataset.pageUrl || window.location.href;
     const summary = container.dataset.pageSummary || '';
-    const article = document.querySelector('article.book-article');
-    const pageText = article ? article.innerText : '';
-    const context = trimmed(pageText || summary, 1800);
+    const pageText = document.querySelector('article.book-article')?.innerText || '';
+    const context = trimText(pageText || summary, 2200);
 
     return [
-      'I am reading a documentation page and need help from this exact content.',
-      'Title: ' + title,
-      'URL: ' + pageUrl,
+      'Help me with this documentation page.',
+      `Title: ${title}`,
+      `URL: ${pageUrl}`,
       '',
-      'Page Content Context:',
+      'Context:',
       context,
       '',
-      'Please summarize the page and provide implementation-focused guidance with concrete examples.'
+      'Please summarize key points and provide practical implementation guidance.'
     ].join('\n');
   }
 
-  function providerUrl(provider, prompt) {
-    const encoded = encodeURIComponent(prompt);
-    if (provider === 'chatgpt') return 'https://chatgpt.com/?q=' + encoded;
-    if (provider === 'gemini') return 'https://gemini.google.com/app?prompt=' + encoded;
-    return 'https://claude.ai/new?q=' + encoded;
-  }
-
-  container.querySelectorAll('[data-ai]').forEach((btn) => {
-    btn.addEventListener('click', function (event) {
+  container.querySelectorAll('[data-ai]').forEach((button) => {
+    button.addEventListener('click', (event) => {
       event.preventDefault();
       const prompt = buildPrompt();
-      const targetUrl = providerUrl(btn.dataset.ai, prompt);
-      btn.href = targetUrl;
+      const provider = providers[button.dataset.ai];
+      if (!provider) return;
+      const targetUrl = provider(prompt);
       window.open(targetUrl, '_blank', 'noopener,noreferrer');
 
-      if (btn.dataset.ai === 'gemini' && navigator.clipboard?.writeText) {
+      if (button.dataset.ai === 'gemini' && navigator.clipboard?.writeText) {
         navigator.clipboard.writeText(prompt).catch(() => {});
       }
     });

--- a/static/custom.css
+++ b/static/custom.css
@@ -62,6 +62,7 @@ body,
     color: #555;
 }
 
+
 .doc-ai-actions {
   display: flex;
   justify-content: flex-end;
@@ -74,12 +75,12 @@ body,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #d4d4d8;
-  background: #fff;
+  border: 1px solid #e4e4e7;
+  background: #fafafa;
   color: #27272a;
   border-radius: 999px;
-  padding: 0.35rem 0.8rem;
-  font-size: 0.85rem;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.82rem;
   font-weight: 600;
   text-decoration: none;
   transition: all 0.15s ease;
@@ -87,27 +88,16 @@ body,
 
 .doc-ai-btn:hover {
   border-color: #a1a1aa;
+  background: #ffffff;
   color: #111827;
   text-decoration: none;
 }
 
-.doc-ai-btn.chatgpt:hover {
-  border-color: #10a37f;
-  color: #0f766e;
-}
-
-.doc-ai-btn.gemini:hover {
-  border-color: #2563eb;
-  color: #1d4ed8;
-}
-
-.doc-ai-btn.claude:hover {
-  border-color: #9333ea;
-  color: #7e22ce;
-}
+.doc-ai-btn.chatgpt:hover { border-color: #10a37f; color: #0f766e; }
+.doc-ai-btn.gemini:hover { border-color: #2563eb; color: #1d4ed8; }
+.doc-ai-btn.claude:hover { border-color: #9333ea; color: #7e22ce; }
 
 @media (max-width: 768px) {
-  .doc-ai-actions {
-    justify-content: flex-start;
-  }
+  .doc-ai-actions { justify-content: flex-start; }
 }
+


### PR DESCRIPTION
### Motivation

- Rebuild a complete developer + user documentation set from the available source (Hugo site and compiled Python bytecode) because editable app sources were not present and the docs needed to reflect actual code structure and APIs. 
- Surface contextual AI helper actions on every documentation page so readers can send the current page content to popular assistants quickly and consistently. 

### Description

- Recreated a structured documentation section under `content.en/docs/recreated` with pages: `introduction-and-problem.md`, `architecture-and-domain-model.md`, `installation-configuration-usage.md`, `api-hooks-security-extensibility.md`, and a top-level `_index.md` that summarize purpose, architecture, doctypes, workflows, APIs, hooks, configuration, extensibility, and limitations inferred from the code. 
- Added a shared page partial `layouts/_partials/docs/ai-page-actions.html` that renders three visible action buttons (`Ask ChatGPT`, `Ask Gemini`, `Ask Claude`) at the top-right of documentation pages and includes a small client script that: builds a trimmed context prompt (title, URL, excerpt/page text), opens the selected provider in a new tab with the prompt encoded in the URL, and copies the prompt to clipboard for Gemini as a fallback. 
- Consolidated and simplified button styling in `assets/custom.css` and `static/custom.css` to ensure the buttons are visible, pill-shaped, and consistent with the site theme (hover accents for each provider). 
- Kept prompt length bounded to avoid URL-size issues and used a minimal, unobtrusive UI pattern consistent with the site’s docs layout. 
- All documentation content and UI changes were prepared on the `docs` branch and staged as the documentation deliverable (no application logic was modified). 

### Testing

- Performed static analysis of compiled app bytecode to enumerate callable functions, doctypes, constants and to drive the recreated docs (scripted `.pyc` inspection succeeded). ✅
- Validated repository diffs and staged changes via status/diff checks (`git status` / `git diff --stat`) to confirm modified files: `content.en/docs/recreated/*`, `layouts/_partials/docs/ai-page-actions.html`, `assets/custom.css`, and `static/custom.css`. ✅
- Attempted to run the Hugo site build (`hugo --minify`) but it failed because `hugo` is not available in the execution environment, so a local site build could not be verified here. ❌
- Attempted an automated UI screenshot via Playwright to validate the rendered buttons, but the Chromium process crashed in this environment, so no screenshot artifact was produced. ⚠️

If you want, I can (1) run a local `hugo` build and produce screenshots in an environment that has `hugo` and a working browser, or (2) adjust the prompt text/template or provider URLs (they are currently set to simple prefill URLs) before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc77ec130832b9b8e10979c2d0696)