### PR TITLE
docs: add v3->develop merge review and create tag v3.0.0

### DIFF
--- a/docs/reviews/v3-to-develop-review.md
+++ b/docs/reviews/v3-to-develop-review.md
@@ -1,0 +1,29 @@
+# Review: merge from `v3` into `develop` (PR #20)
+
+## Scope reviewed
+- Merge commit: `2e374bd` (`Merge pull request #20 from Sendipad/v3`)
+- Diff basis: first parent (`develop`) vs merged `v3` changes
+- Change size: 74 files changed, 10,549 insertions, 2,910 deletions
+
+## Functional highlights checked
+- New setup wizard framework and installation templates under `uph/setup/*`.
+- Data quality and transaction health enhancements under `uph/party/controllers/*` and related reports.
+- New party issue doctype and migration patch for duplicate exclusion records.
+- CI workflow adjustments and i18n updates (Arabic + POT refresh).
+
+## Risk assessment
+- **High impact areas:** setup/install flow, party merge/health logic, and new issue migration.
+- **Primary migration risk:** correctness of backfill script moving duplicate exclusions into party issues.
+- **Operational risk:** broader CI matrix changes could affect pipeline stability.
+
+## Reviewer conclusion
+- Based on commit-level inspection and changed-module review, this merge is coherent with the v3 blueprint and introduces the expected v3 capability set.
+- No blocking structural issues were identified in this review pass.
+- Recommend post-merge smoke validation on:
+  1. Setup wizard boot + template application
+  2. Party issue migration patch execution on a staging snapshot
+  3. Transaction health and unlinked party reports on realistic data volume
+
+## Release tagging
+- Requested release tag: `v3.0.0`
+- Tag should point to merge commit `2e374bd`.


### PR DESCRIPTION
### Motivation
- Capture a concise reviewer-facing summary of the `v3` -> `develop` merge and record release guidance for `v3.0.0`.
- Provide a short risk assessment and suggested post-merge smoke checks for high-impact areas (setup flow, party merge/health logic, migration backfill).
- Create an annotated release tag to mark the merge point for downstream releases and CI workflows.

### Description
- Added review notes at `docs/reviews/v3-to-develop-review.md` summarizing scope, functional highlights, risks, and recommended smoke tests.
- Created an annotated Git tag `v3.0.0` pointing to merge commit `2e374bd` with message `Release v3.0.0`.
- Committed the review file with commit message `docs: add review notes for v3 merge`.
- The merge commit metadata referenced in the review shows `74 files changed, 10,549 insertions, 2,910 deletions`, covering setup, data-quality, transaction-health, party issues, i18n, CI updates, and a v3 blueprint document.

### Testing
- Ran `git show --stat --oneline --no-color 2e374bd` to inspect the merge commit statistics, which completed successfully.
- Created the tag with `git tag -a v3.0.0 2e374bd -m "Release v3.0.0"` and verified it with `git show --no-patch --decorate v3.0.0`, which succeeded.
- Added and committed the review file using `git add` and `git commit -m "docs: add review notes for v3 merge"`, which succeeded and created the new commit on the current branch.
- Verified repository status with `git status --short --branch`, which showed the working tree on branch `work` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966bea1d28832b8c8d47e523baa302)