### PR TITLE
feat(dashboard): improve stats cards, add party master filter, and fix unlinked vouchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,19 @@ jobs:
       setuptools_version: "<70"
       run_python: ${{ needs.changes.outputs.python == 'true' || needs.changes.outputs.config == 'true' }}
       run_ui: ${{ needs.changes.outputs.javascript == 'true' || needs.changes.outputs.config == 'true' }}
+
+  tests_passed:
+    name: All Tests Passed
+    needs: [test_v15, test_v16, test_v17]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test outcomes
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]; then
+            echo "Tests failed!"
+            exit 1
+          else
+            echo "Tests passed or were intentionally skipped!"
+            exit 0
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,13 @@ jobs:
     name: v17
     needs: changes
     if: |
-      github.ref_name != 'hotfix' &&
-      github.event.pull_request.head.ref != 'hotfix' &&
-      (github.event_name == 'workflow_dispatch' ||
-       github.ref == 'refs/heads/develop' ||
-       needs.changes.outputs.python == 'true' ||
-       needs.changes.outputs.javascript == 'true' ||
-       needs.changes.outputs.config == 'true')
+      github.event_name == 'workflow_dispatch' ||
+      github.ref_name == 'hotfix' ||
+      github.event.pull_request.head.ref == 'hotfix' ||
+      github.ref == 'refs/heads/develop' ||
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.javascript == 'true' ||
+      needs.changes.outputs.config == 'true'
     uses: ./.github/workflows/reusable_test.yml
     with:
       frappe_branch: "develop"
@@ -68,13 +68,13 @@ jobs:
     name: v16
     needs: changes
     if: |
-      github.ref_name != 'hotfix' &&
-      github.event.pull_request.head.ref != 'hotfix' &&
-      (github.event_name == 'workflow_dispatch' ||
-       github.ref == 'refs/heads/version-16' ||
-       needs.changes.outputs.python == 'true' ||
-       needs.changes.outputs.javascript == 'true' ||
-       needs.changes.outputs.config == 'true')
+      github.event_name == 'workflow_dispatch' ||
+      github.ref_name == 'hotfix' ||
+      github.event.pull_request.head.ref == 'hotfix' ||
+      github.ref == 'refs/heads/version-16' ||
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.javascript == 'true' ||
+      needs.changes.outputs.config == 'true'
     uses: ./.github/workflows/reusable_test.yml
     with:
       frappe_branch: "version-16"

--- a/test_all_output.txt
+++ b/test_all_output.txt
@@ -1,0 +1,90 @@
+...............................................................................
+test_duplicate_check_disabled (uph.tests.test_duplicate_bypass.TestDuplicateBypass) (2.1s)
+.
+test_duplicate_check_enabled_warn (uph.tests.test_duplicate_bypass.TestDuplicateBypass) (2.97s)
+.........................................EE................
+test_case_b_relink_customers_different_currency (uph.tests.test_party_merge.TestPartyMergeService)
+Test Case B: Two PMs with Customers having different currencies. (2.33s)
+..........
+test_get_party_master_dashboard_info (uph.tests.test_queries.TestQueries) (4.21s)
+.
+test_get_party_master_dashboard_info_group_aggregation (uph.tests.test_queries.TestQueries) (7.88s)
+.......................
+======================================================================
+ERROR: test_create_party_issue_idempotent (uph.tests.test_party_issue.TestPartyIssue)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "/home/erpnext/frappe-bench/apps/frappe/frappe/model/base_document.py", line 576, in db_insert
+    frappe.db.sql(
+  File "/home/erpnext/frappe-bench/apps/frappe/frappe/database/database.py", line 230, in sql
+    self._cursor.execute(query, values)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 153, in execute
+    result = self._query(query)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 322, in _query
+    conn.query(q)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 563, in query
+    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 825, in _read_query_result
+    result.read()
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 1199, in read
+    first_packet = self.connection._read_packet()
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 775, in _read_packet
+    packet.raise_for_error()
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/protocol.py", line 219, in raise_for_error
+    err.raise_mysql_exception(self._data)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
+    raise errorclass(errno, errval)
+pymysql.err.IntegrityError: (1062, "Duplicate entry '3000030149' for key 'PRIMARY'")
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/home/erpnext/frappe-bench/apps/uph/uph/tests/test_party_issue.py", line 17, in setUp
+    self.party = frappe.get_doc(
+  File "/home/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 320, in insert
+    self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
+  File "/home/erpnext/frappe-bench/apps/frappe/frappe/model/base_document.py", line 603, in db_insert
+    raise frappe.DuplicateEntryError(self.doctype, self.name, e)
+frappe.exceptions.DuplicateEntryError: ('Party Master', '3000030149', IntegrityError(1062, "Duplicate entry '3000030149' for key 'PRIMARY'"))
+
+======================================================================
+ERROR: test_resolved_metadata (uph.tests.test_party_issue.TestPartyIssue)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "/home/erpnext/frappe-bench/apps/frappe/frappe/model/base_document.py", line 576, in db_insert
+    frappe.db.sql(
+  File "/home/erpnext/frappe-bench/apps/frappe/frappe/database/database.py", line 230, in sql
+    self._cursor.execute(query, values)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 153, in execute
+    result = self._query(query)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 322, in _query
+    conn.query(q)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 563, in query
+    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 825, in _read_query_result
+    result.read()
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 1199, in read
+    first_packet = self.connection._read_packet()
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 775, in _read_packet
+    packet.raise_for_error()
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/protocol.py", line 219, in raise_for_error
+    err.raise_mysql_exception(self._data)
+  File "/home/erpnext/frappe-bench/env/lib/python3.10/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
+    raise errorclass(errno, errval)
+pymysql.err.IntegrityError: (1062, "Duplicate entry '3000030149' for key 'PRIMARY'")
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/home/erpnext/frappe-bench/apps/uph/uph/tests/test_party_issue.py", line 17, in setUp
+    self.party = frappe.get_doc(
+  File "/home/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 320, in insert
+    self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
+  File "/home/erpnext/frappe-bench/apps/frappe/frappe/model/base_document.py", line 603, in db_insert
+    raise frappe.DuplicateEntryError(self.doctype, self.name, e)
+frappe.exceptions.DuplicateEntryError: ('Party Master', '3000030149', IntegrityError(1062, "Duplicate entry '3000030149' for key 'PRIMARY'"))
+
+----------------------------------------------------------------------
+Ran 173 tests in 38.557s
+
+FAILED (errors=2)

--- a/uph/__init__.py
+++ b/uph/__init__.py
@@ -5,7 +5,7 @@ from uph.party.controllers.queries import (
 )
 from uph.party.controllers.cache_utils import SmartCache
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 
 # ----------------------------------------------------------------------------

--- a/uph/party/controllers/party.py
+++ b/uph/party/controllers/party.py
@@ -272,6 +272,21 @@ def validate_party_master_on_target_party_type(doc, method):
         # Sync Naming if enabled
         sync_party_name_from_party_master(doc)
 
+        # Enforce cross-type uniqueness
+        settings = frappe.get_cached_doc("Party Master Settings")
+        if settings.enforce_cross_type_uniqueness and doc.name:
+            from uph.party.controllers.cache_utils import get_configured_party_types
+
+            for pt in get_configured_party_types():
+                if pt == doc.doctype:
+                    continue
+                if frappe.db.exists(pt, doc.name):
+                    frappe.throw(
+                        _(
+                            "Party '{0}' already exists as a {1}. Cross-type uniqueness is enforced."
+                        ).format(doc.name, pt)
+                    )
+
     if method == "on_update":
         old_doc = doc.get_doc_before_save()
         old_party_master = old_doc.get("party_master") if old_doc else None
@@ -836,15 +851,18 @@ def sync_party_name_from_party_master(doc):
     # Determine if this is a secondary role
     is_primary = pm.party_type == party_type
 
+    # 2-letter abbreviation
+    abbr = party_type[:2].lower()
+
     if mode and "Prefix" in mode:
-        prefix = f"{party_type}-"
+        prefix = f"{abbr}-"
         if mode == "Prefix for All Role":
             new_name = f"{prefix}{pm.party_number}"
         elif mode == "Prefix for Secondary Role" and not is_primary:
             new_name = f"{prefix}{pm.party_number}"
 
     elif mode and "Suffix" in mode:
-        suffix = f"-{party_type}"
+        suffix = f"-{abbr}"
         if mode == "Suffix for All Role":
             new_name = f"{pm.party_number}{suffix}"
         elif mode == "Suffix Secondary Roles" and not is_primary:

--- a/uph/party/controllers/transaction_health.py
+++ b/uph/party/controllers/transaction_health.py
@@ -143,21 +143,25 @@ def get_transaction_health(
 
 
 @frappe.whitelist()
-def get_party_health_detail(party_master: str):
+def get_party_health_detail(party_master: str, reference_doctype: str = None):
     """
     Drill-down: list individual policy issues for a given Party Master.
     """
     if not frappe.db.exists("Party Master", party_master):
         frappe.throw(_("Party Master {0} does not exist").format(party_master))
 
+    filters = {
+        "issue_type": "Transaction Policy",
+        "status": ["in", ["Open", "Under Review"]],
+        "party": party_master,
+    }
+    if reference_doctype:
+        filters["reference_doctype"] = reference_doctype
+
     issues = frappe.get_all(
         "Party Issue",
-        filters={
-            "issue_type": "Transaction Policy",
-            "status": ["in", ["Open", "Under Review"]],
-            "party": party_master,
-        },
-        fields=["reference_doctype", "reference_name", "details_json"],
+        filters=filters,
+        fields=["name", "reference_doctype", "reference_name", "details_json"],
         limit_page_length=0,
     )
 

--- a/uph/party/controllers/transaction_health.py
+++ b/uph/party/controllers/transaction_health.py
@@ -23,7 +23,12 @@ from uph.party.controllers.cache_utils import (
 
 
 @frappe.whitelist()
-def get_transaction_health(limit: int = 20, offset: int = 0, party_master: str = None):
+def get_transaction_health(
+    limit: int = 20,
+    offset: int = 0,
+    party_master: str = None,
+    reference_doctype: str = None,
+):
     """
     Find Party Masters with open Transaction Policy issues.
     Returns paginated list aggregated by (party, reference_doctype), sorted by doctype.
@@ -54,8 +59,12 @@ def get_transaction_health(limit: int = 20, offset: int = 0, party_master: str =
     party_filter = ""
     params = {}
     if party_master:
-        party_filter = "AND pi.party = %(party_master)s"
+        party_filter += " AND pi.party = %(party_master)s"
         params["party_master"] = party_master
+
+    if reference_doctype:
+        party_filter += " AND pi.reference_doctype = %(reference_doctype)s"
+        params["reference_doctype"] = reference_doctype
 
     agg_rows = frappe.db.sql(
         f"""
@@ -173,10 +182,98 @@ def get_party_health_detail(party_master: str):
                 "doctype": issue.reference_doctype,
                 "name": issue.reference_name,
                 "issue_type": issue_type,
+                "issue_code": code,
+                "issue_name": issue.name,
+                "docstatus": (
+                    frappe.db.get_value(
+                        issue.reference_doctype, issue.reference_name, "docstatus"
+                    )
+                    if frappe.db.exists(issue.reference_doctype, issue.reference_name)
+                    else None
+                ),
+                "creation": (
+                    frappe.db.get_value(
+                        issue.reference_doctype, issue.reference_name, "creation"
+                    )
+                    if frappe.db.exists(issue.reference_doctype, issue.reference_name)
+                    else None
+                ),
             }
         )
 
     return {"vouchers": vouchers, "total": len(vouchers)}
+
+
+@frappe.whitelist()
+def resolve_health_issue(issue_name: str, action: str):
+    """
+    Resolve a specific transaction health issue (e.g. submit draft, cancel).
+    Action can be 'submit', 'cancel', or 'dismiss'.
+    """
+    if not frappe.has_permission("Party Issue", "write"):
+        frappe.throw(_("Not permitted to write Party Issue"))
+
+    issue = frappe.get_doc("Party Issue", issue_name)
+    if not issue or issue.issue_type != "Transaction Policy":
+        frappe.throw(_("Invalid Party Issue"))
+
+    dt = issue.reference_doctype
+    dn = issue.reference_name
+    now = now_datetime()
+
+    try:
+        if action == "submit":
+            if not frappe.db.exists(dt, dn):
+                frappe.throw(_("{0} {1} no longer exists").format(dt, dn))
+            doc = frappe.get_doc(dt, dn)
+            if doc.docstatus == 0:
+                doc.submit()
+            issue.status = "Resolved"
+            issue.resolved_on = now
+            issue.resolved_by = frappe.session.user
+            issue.save(ignore_permissions=True)
+            return {
+                "success": True,
+                "message": _("{0} submitted successfully").format(dn),
+            }
+
+        elif action == "cancel":
+            if not frappe.db.exists(dt, dn):
+                frappe.throw(_("{0} {1} no longer exists").format(dt, dn))
+            doc = frappe.get_doc(dt, dn)
+            if doc.docstatus == 1:
+                doc.cancel()
+            issue.status = "Resolved"
+            issue.resolved_on = now
+            issue.resolved_by = frappe.session.user
+            issue.save(ignore_permissions=True)
+            return {
+                "success": True,
+                "message": _("{0} cancelled successfully").format(dn),
+            }
+
+        elif action == "dismiss":
+            issue.status = "Ignored"
+            issue.resolved_on = now
+            issue.resolved_by = frappe.session.user
+
+            details = {}
+            if issue.details_json:
+                try:
+                    details = json.loads(issue.details_json)
+                except:
+                    pass
+            details["dismiss_reason"] = "Dismissed from Dashboard"
+            issue.details_json = json.dumps(details)
+            issue.save(ignore_permissions=True)
+            return {"success": True, "message": _("Issue dismissed")}
+
+        else:
+            frappe.throw(_("Unknown action {0}").format(action))
+
+    except Exception as e:
+        frappe.log_error(title="Failed to resolve health issue", message=str(e))
+        return {"success": False, "message": str(e)}
 
 
 def enqueue_transaction_policy_scan():

--- a/uph/party/controllers/transaction_health.py
+++ b/uph/party/controllers/transaction_health.py
@@ -23,52 +23,66 @@ from uph.party.controllers.cache_utils import (
 
 
 @frappe.whitelist()
-def get_transaction_health(limit: int = 20, offset: int = 0):
+def get_transaction_health(limit: int = 20, offset: int = 0, party_master: str = None):
     """
     Find Party Masters with open Transaction Policy issues.
-    Returns paginated list of parties with problem counts.
+    Returns paginated list aggregated by (party, reference_doctype), sorted by doctype.
+    Severity is determined by per-doctype warn_not_submitted_document setting.
     """
     limit = cint(limit) or 20
     offset = cint(offset) or 0
 
-    issues = frappe.get_all(
-        "Party Issue",
-        filters={
-            "issue_type": "Transaction Policy",
-            "status": ["in", ["Open", "Under Review"]],
-        },
-        fields=["party", "details_json"],
-        limit_page_length=0,
+    # Read per-doctype warn_not_submitted_document from settings child table
+    warn_doctypes = set()
+    try:
+        settings = frappe.get_cached_doc("Party Master Settings")
+        for d in settings.document_types or []:
+            if getattr(d, "warn_not_submitted_document", 0):
+                dt = d.get("document_type")
+                parent_dt = d.get("parent_doctype") or dt
+                warn_doctypes.add(dt)
+                warn_doctypes.add(parent_dt)
+    except Exception as e:
+        frappe.log_error(
+            title="Transaction Health: Failed to load warn_not_submitted_document settings",
+            message=str(e),
+        )
+
+    # ── SQL aggregation: GROUP BY party, reference_doctype ──
+    # Use JSON_EXTRACT to classify each issue by its sub-type directly
+    # in SQL, drastically reducing Python-side work.
+    party_filter = ""
+    params = {}
+    if party_master:
+        party_filter = "AND pi.party = %(party_master)s"
+        params["party_master"] = party_master
+
+    agg_rows = frappe.db.sql(
+        f"""
+        SELECT
+            pi.party,
+            pi.reference_doctype,
+            SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(pi.details_json, '$.issue')) = 'draft_overdue' THEN 1 ELSE 0 END) AS draft_count,
+            SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(pi.details_json, '$.issue')) = 'cancelled_referenced' THEN 1 ELSE 0 END) AS cancelled_unamended_count,
+            SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(pi.details_json, '$.issue')) = 'party_master_mismatch' THEN 1 ELSE 0 END) AS mismatch_count,
+            COUNT(*) AS total_issues
+        FROM `tabParty Issue` pi
+        WHERE pi.issue_type = 'Transaction Policy'
+          AND pi.status IN ('Open', 'Under Review')
+          AND pi.party IS NOT NULL
+          AND pi.party != ''
+          {party_filter}
+        GROUP BY pi.party, pi.reference_doctype
+        """,
+        params,
+        as_dict=True,
     )
 
-    if not issues:
+    if not agg_rows:
         return {"parties": [], "total": 0}
 
-    party_problems = {}
-    for issue in issues:
-        pm = issue.party
-        if not pm:
-            continue
-        party_problems.setdefault(
-            pm,
-            {"draft_count": 0, "cancelled_unamended_count": 0, "mismatch_count": 0},
-        )
-        if issue.details_json:
-            try:
-                details = json.loads(issue.details_json)
-            except Exception:
-                details = {}
-        else:
-            details = {}
-        code = details.get("issue")
-        if code == "draft_overdue":
-            party_problems[pm]["draft_count"] += 1
-        elif code == "cancelled_referenced":
-            party_problems[pm]["cancelled_unamended_count"] += 1
-        elif code == "party_master_mismatch":
-            party_problems[pm]["mismatch_count"] += 1
-
-    pm_names = list(party_problems.keys())
+    # Bulk-fetch party details
+    pm_names = list(set(r.party for r in agg_rows))
     pm_details = {}
     for pm in frappe.get_all(
         "Party Master",
@@ -78,35 +92,45 @@ def get_transaction_health(limit: int = 20, offset: int = 0):
         pm_details[pm.name] = pm
 
     results = []
-    for pm_name, counts in party_problems.items():
-        detail = pm_details.get(pm_name, {})
-        total_issues = (
-            counts["draft_count"]
-            + counts["cancelled_unamended_count"]
-            + counts["mismatch_count"]
-        )
+    for row in agg_rows:
+        detail = pm_details.get(row.party, {})
+        ref_dt = row.reference_doctype or ""
+        total = cint(row.total_issues)
+
+        # Per-doctype severity: if warn_not_submitted_document is checked
+        # for this doctype, severity is always High
+        if ref_dt in warn_doctypes:
+            severity = "High"
+        else:
+            severity = "High" if total >= 10 else ("Medium" if total >= 3 else "Low")
+
         results.append(
             {
-                "party_master": pm_name,
-                "party_name": detail.get("party_name", pm_name),
+                "party_master": row.party,
+                "party_name": detail.get("party_name", row.party),
                 "party_type": detail.get("party_type", ""),
                 "party_number": detail.get("party_number", ""),
-                "draft_count": counts["draft_count"],
-                "cancelled_unamended_count": counts["cancelled_unamended_count"],
-                "total_issues": total_issues,
-                "severity": (
-                    "High"
-                    if total_issues >= 10
-                    else ("Medium" if total_issues >= 3 else "Low")
-                ),
+                "reference_doctype": ref_dt,
+                "draft_count": cint(row.draft_count),
+                "cancelled_unamended_count": cint(row.cancelled_unamended_count),
+                "total_issues": total,
+                "severity": severity,
             }
         )
 
-    results.sort(key=lambda x: x["total_issues"], reverse=True)
-    total = len(results)
+    # Sort: High severity first, then by reference_doctype, then total_issues desc
+    severity_order = {"High": 0, "Medium": 1, "Low": 2}
+    results.sort(
+        key=lambda x: (
+            severity_order.get(x["severity"], 9),
+            x["reference_doctype"],
+            -x["total_issues"],
+        )
+    )
+    total_count = len(results)
     paginated = results[offset : offset + limit]
 
-    return {"parties": paginated, "total": total}
+    return {"parties": paginated, "total": total_count}
 
 
 @frappe.whitelist()

--- a/uph/party/controllers/unlinked_resolver.py
+++ b/uph/party/controllers/unlinked_resolver.py
@@ -602,6 +602,77 @@ def enqueue_unlinked_issue_scan():
     )
 
 
+@frappe.whitelist()
+def resolve_unlinked_voucher(role_doctype: str, role_name: str, party_master: str):
+    """
+    Called from the Dashboard's Unlinked Vouchers tab.
+    Links the underlying role (e.g. Customer, Supplier) to a Party Master.
+    This naturally cascades to the historical voucher and resolves the issue.
+    """
+    if not frappe.has_permission(role_doctype, "write"):
+        frappe.throw(_("Not permitted to write to {0}").format(role_doctype))
+    if not frappe.has_permission("Party Master", "read"):
+        frappe.throw(_("Not permitted to read Party Master"))
+
+    # Link the underlying role using the existing robust method
+    result = link_to_party_master(role_doctype, role_name, party_master)
+
+    # Additionally, resolve any open Unlinked Voucher issues for this specific transaction
+    # (Though technically, the next scan or patch would auto-resolve it, doing it here is instant UI feedback)
+    issues = frappe.get_all(
+        "Party Issue",
+        filters={
+            "issue_type": "Unlinked",
+            "status": ["in", ["Open", "Under Review"]],
+        },
+        fields=["name", "reference_doctype", "reference_name"],
+    )
+
+    now = now_datetime()
+    for issue in issues:
+        dt = issue.reference_doctype
+        name = issue.reference_name
+        if not dt or not name:
+            continue
+
+        # Check if this voucher references the role we just linked
+        # e.g. Sales Invoice has customer = role_name
+        meta = frappe.get_meta(dt)
+        role_fieldname = None
+        for candidate in [
+            f"{role_doctype.lower().replace(' ', '_')}",
+            f"{role_doctype.lower().replace(' ', '_')}_name",
+            "party",
+        ]:
+            if meta.has_field(candidate):
+                role_fieldname = candidate
+                break
+
+        if role_fieldname:
+            voucher_role = frappe.db.get_value(dt, name, role_fieldname)
+            if voucher_role == role_name:
+                # Update the voucher's party_master instantly
+                frappe.db.set_value(
+                    dt, name, "party_master", party_master, update_modified=False
+                )
+                # Resolve the issue
+                frappe.db.set_value(
+                    "Party Issue",
+                    issue.name,
+                    {
+                        "status": "Resolved",
+                        "resolved_on": now,
+                        "resolved_by": frappe.session.user,
+                    },
+                    update_modified=False,
+                )
+
+    return {
+        "success": True,
+        "message": _("{0} has been linked to {1}").format(role_name, party_master),
+    }
+
+
 def run_unlinked_issue_scan():
     """
     Scan for unlinked role records and create Party Issue entries.

--- a/uph/party/controllers/unlinked_resolver.py
+++ b/uph/party/controllers/unlinked_resolver.py
@@ -126,6 +126,8 @@ def get_unlinked_transactions(
     """
     Find ERPNext transactions where party_master is NULL or empty.
     Vouchers like Sales Invoice, Payment Entry, etc.
+    For child doctypes (e.g. Journal Entry Account), resolves the parent
+    document name so the UI links to the parent (e.g. Journal Entry).
     """
     limit = cint(limit) or 20
     offset = cint(offset) or 0
@@ -153,22 +155,39 @@ def get_unlinked_transactions(
         # Count
         total += frappe.db.count(dt, {"party_master": ["in", [None, ""]]})
 
-        owner_expr = "''"
-        if meta.has_field("owner"):
-            owner_expr = "COALESCE(`owner`, '')"
+        is_child = meta.istable
 
-        selects.append(
-            f"""
-            SELECT
-                {frappe.db.escape(dt)} AS role_doctype,
-                `name` AS role_name,
-                CONCAT({frappe.db.escape(dt)}, ': ', `name`) AS display_name,
-                {owner_expr} AS owner,
-                `creation` AS creation
-            FROM `tab{dt}`
-            WHERE (party_master IS NULL OR party_master = '')
-        """
-        )
+        if is_child:
+            # For child doctypes, return the parent document name and doctype
+            selects.append(
+                f"""
+                SELECT
+                    `parenttype` AS role_doctype,
+                    `parent` AS role_name,
+                    CONCAT(`parenttype`, ': ', `parent`) AS display_name,
+                    '' AS owner,
+                    `creation` AS creation
+                FROM `tab{dt}`
+                WHERE (party_master IS NULL OR party_master = '')
+            """
+            )
+        else:
+            owner_expr = "''"
+            if meta.has_field("owner"):
+                owner_expr = "COALESCE(`owner`, '')"
+
+            selects.append(
+                f"""
+                SELECT
+                    {frappe.db.escape(dt)} AS role_doctype,
+                    `name` AS role_name,
+                    CONCAT({frappe.db.escape(dt)}, ': ', `name`) AS display_name,
+                    {owner_expr} AS owner,
+                    `creation` AS creation
+                FROM `tab{dt}`
+                WHERE (party_master IS NULL OR party_master = '')
+            """
+            )
 
     if not selects:
         return {"unlinked": [], "total": total}
@@ -460,14 +479,18 @@ def _find_best_parent_group_for_role(role_doctype: str):
 
 
 @frappe.whitelist()
-def get_unlinked_issues(limit: int = 20, offset: int = 0):
+def get_unlinked_issues(limit: int = 20, offset: int = 0, party_master: str = None):
     """
     Fetch unlinked issues from Party Issue (governance registry).
+    For child doctypes, resolves the parent document name from the
+    child row's `parent` field so the UI can link to it correctly.
     """
     limit = cint(limit) or 20
     offset = cint(offset) or 0
 
     filters = {"issue_type": "Unlinked", "status": ["in", ["Open", "Under Review"]]}
+    if party_master:
+        filters["party"] = party_master
     issues = frappe.get_all(
         "Party Issue",
         filters=filters,
@@ -494,20 +517,27 @@ def get_unlinked_issues(limit: int = 20, offset: int = 0):
         if not frappe.has_permission(dt, "read"):
             continue
         meta = frappe.get_meta(dt)
+        is_child = meta.istable
+
         fields = ["name"]
-        name_field = None
-        for candidate in [
-            f"{dt.lower().replace(' ', '_')}_name",
-            "employee_name",
-            "customer_name",
-            "supplier_name",
-        ]:
-            if meta.has_field(candidate):
-                name_field = candidate
-                fields.append(candidate)
-                break
-        if meta.has_field("default_currency"):
-            fields.append("default_currency")
+        if is_child:
+            # For child tables, fetch parent and parenttype
+            fields.extend(["parent", "parenttype"])
+        else:
+            name_field = None
+            for candidate in [
+                f"{dt.lower().replace(' ', '_')}_name",
+                "employee_name",
+                "customer_name",
+                "supplier_name",
+            ]:
+                if meta.has_field(candidate):
+                    name_field = candidate
+                    fields.append(candidate)
+                    break
+            if meta.has_field("default_currency"):
+                fields.append("default_currency")
+
         rows = frappe.get_all(dt, filters={"name": ["in", names]}, fields=fields)
         for r in rows:
             records_map[(dt, r.name)] = r
@@ -519,22 +549,41 @@ def get_unlinked_issues(limit: int = 20, offset: int = 0):
         record = records_map.get((dt, name))
         if not record:
             continue
-        display = record.get(
-            f"{dt.lower().replace(' ', '_')}_name",
-            record.get("customer_name")
-            or record.get("supplier_name")
-            or record.get("employee_name")
-            or record.name,
-        )
-        result.append(
-            {
-                "role_doctype": dt,
-                "role_name": name,
-                "display_name": display,
-                "currency": record.get("default_currency", ""),
-                "issue": issue.name,
-            }
-        )
+
+        meta = frappe.get_meta(dt)
+        is_child = meta.istable
+
+        if is_child:
+            # Use parent document name and doctype for display/linking
+            parent_name = record.get("parent", name)
+            parent_doctype = record.get("parenttype", dt)
+            display = f"{parent_doctype}: {parent_name}"
+            result.append(
+                {
+                    "role_doctype": parent_doctype,
+                    "role_name": parent_name,
+                    "display_name": display,
+                    "currency": "",
+                    "issue": issue.name,
+                }
+            )
+        else:
+            display = record.get(
+                f"{dt.lower().replace(' ', '_')}_name",
+                record.get("customer_name")
+                or record.get("supplier_name")
+                or record.get("employee_name")
+                or record.name,
+            )
+            result.append(
+                {
+                    "role_doctype": dt,
+                    "role_name": name,
+                    "display_name": display,
+                    "currency": record.get("default_currency", ""),
+                    "issue": issue.name,
+                }
+            )
 
     total = frappe.db.count("Party Issue", filters)
     return {"unlinked": result, "total": total}

--- a/uph/party/doctype/duplicate_exclusion/duplicate_exclusion.json
+++ b/uph/party/doctype/duplicate_exclusion/duplicate_exclusion.json
@@ -1,162 +1,175 @@
 {
- "actions": [],
- "autoname": "hash",
- "creation": "2026-02-05 17:45:00",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "party_1",
-  "party_2",
-  "column_break_1",
-  "status",
-  "dismissed_on",
-  "dismissed_by",
-  "section_break_2",
-  "dismissed_reason",
-  "detection_metadata_section",
-  "similarity_score",
-  "column_break_det1",
-  "detected_on",
-  "normalized_names_section",
-  "normalized_name_1",
-  "column_break_det2",
-  "normalized_name_2"
- ],
- "fields": [
-  {
-   "fieldname": "party_1",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Party 1",
-   "options": "Party Master",
-   "reqd": 1
-  },
-  {
-   "fieldname": "party_2",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Party 2",
-   "options": "Party Master",
-   "reqd": 1
-  },
-  {
-   "fieldname": "column_break_1",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "__user",
-   "fieldname": "dismissed_by",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Dismissed By",
-   "options": "User",
-   "read_only": 1
-  },
-  {
-   "default": "Today",
-   "fieldname": "dismissed_on",
-   "fieldtype": "Date",
-   "in_list_view": 1,
-   "label": "Dismissed On",
-   "read_only": 1
-  },
-  {
-   "fieldname": "section_break_2",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "dismissed_reason",
-   "fieldtype": "Small Text",
-   "label": "Reason"
-  },
-  {
-   "default": "Detected",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Status",
-   "options": "Dismissed\nDetected\nMerged",
-   "read_only": 1
-  },
-  {
-   "fieldname": "detection_metadata_section",
-   "fieldtype": "Section Break",
-   "label": "Detection Metadata"
-  },
-  {
-   "fieldname": "similarity_score",
-   "fieldtype": "Float",
-   "in_list_view": 1,
-   "label": "Similarity Score",
-   "precision": "1",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_det1",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "Now",
-   "fieldname": "detected_on",
-   "fieldtype": "Datetime",
-   "label": "Detected On",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "normalized_names_section",
-   "fieldtype": "Section Break",
-   "label": "Normalized Names"
-  },
-  {
-   "fieldname": "normalized_name_1",
-   "fieldtype": "Data",
-   "label": "Normalized Name 1",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_det2",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "normalized_name_2",
-   "fieldtype": "Data",
-   "label": "Normalized Name 2",
-   "read_only": 1
-  }
- ],
- "links": [],
- "modified": "2026-02-14 15:59:35.114959",
- "modified_by": "Administrator",
- "module": "Party",
- "name": "Duplicate Exclusion",
- "naming_rule": "Random",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "export": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "export": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts Manager",
-   "write": 1
-  }
- ],
- "row_format": "Dynamic",
- "sort_field": "creation",
- "sort_order": "DESC",
- "states": []
+    "actions": [],
+    "autoname": "hash",
+    "creation": "2026-02-05 17:45:00",
+    "description": "Deprecated",
+    "doctype": "DocType",
+    "engine": "InnoDB",
+    "field_order": [
+        "party_1",
+        "party_2",
+        "column_break_1",
+        "status",
+        "dismissed_on",
+        "dismissed_by",
+        "section_break_2",
+        "dismissed_reason",
+        "detection_metadata_section",
+        "similarity_score",
+        "column_break_det1",
+        "detected_on",
+        "normalized_names_section",
+        "normalized_name_1",
+        "column_break_det2",
+        "normalized_name_2"
+    ],
+    "fields": [
+        {
+            "fieldname": "party_1",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Party 1",
+            "options": "Party Master",
+            "reqd": 1
+        },
+        {
+            "fieldname": "party_2",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Party 2",
+            "options": "Party Master",
+            "reqd": 1
+        },
+        {
+            "fieldname": "column_break_1",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "__user",
+            "fieldname": "dismissed_by",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Dismissed By",
+            "options": "User",
+            "read_only": 1
+        },
+        {
+            "default": "Today",
+            "fieldname": "dismissed_on",
+            "fieldtype": "Date",
+            "in_list_view": 1,
+            "label": "Dismissed On",
+            "read_only": 1
+        },
+        {
+            "fieldname": "section_break_2",
+            "fieldtype": "Section Break"
+        },
+        {
+            "fieldname": "dismissed_reason",
+            "fieldtype": "Small Text",
+            "label": "Reason"
+        },
+        {
+            "default": "Detected",
+            "fieldname": "status",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Status",
+            "options": "Dismissed\nDetected\nMerged",
+            "read_only": 1
+        },
+        {
+            "fieldname": "detection_metadata_section",
+            "fieldtype": "Section Break",
+            "label": "Detection Metadata"
+        },
+        {
+            "fieldname": "similarity_score",
+            "fieldtype": "Float",
+            "in_list_view": 1,
+            "label": "Similarity Score",
+            "precision": "1",
+            "read_only": 1
+        },
+        {
+            "fieldname": "column_break_det1",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "Now",
+            "fieldname": "detected_on",
+            "fieldtype": "Datetime",
+            "label": "Detected On",
+            "read_only": 1
+        },
+        {
+            "collapsible": 1,
+            "fieldname": "normalized_names_section",
+            "fieldtype": "Section Break",
+            "label": "Normalized Names"
+        },
+        {
+            "fieldname": "normalized_name_1",
+            "fieldtype": "Data",
+            "label": "Normalized Name 1",
+            "read_only": 1
+        },
+        {
+            "fieldname": "column_break_det2",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "normalized_name_2",
+            "fieldtype": "Data",
+            "label": "Normalized Name 2",
+            "read_only": 1
+        }
+    ],
+    "links": [],
+    "modified": "2026-02-20 22:39:18.150684",
+    "modified_by": "Administrator",
+    "module": "Party",
+    "name": "Duplicate Exclusion",
+    "naming_rule": "Random",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "export": 1,
+            "read": 1,
+            "report": 1,
+            "role": "System Manager",
+            "write": 1
+        },
+        {
+            "create": 1,
+            "delete": 1,
+            "export": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Accounts Manager",
+            "write": 1
+        },
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Party Manager",
+            "share": 1,
+            "write": 1
+        }
+    ],
+    "row_format": "Dynamic",
+    "sort_field": "creation",
+    "sort_order": "DESC",
+    "states": []
 }

--- a/uph/party/doctype/party_analytic_accounting/party_analytic_accounting.json
+++ b/uph/party/doctype/party_analytic_accounting/party_analytic_accounting.json
@@ -138,11 +138,11 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-20 17:28:51.230685",
+ "modified": "2026-02-21 00:45:28.282955",
  "modified_by": "Administrator",
  "module": "Party",
  "name": "Party Analytic Accounting",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -154,6 +154,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Party Manager",
    "share": 1,
    "write": 1
   }

--- a/uph/party/doctype/party_issue/party_issue.json
+++ b/uph/party/doctype/party_issue/party_issue.json
@@ -1,194 +1,197 @@
 {
-    "actions": [],
-    "autoname": "hash",
-    "creation": "2026-02-17 10:00:00",
-    "doctype": "DocType",
-    "engine": "InnoDB",
-    "field_order": [
-        "details_section",
-        "issue_type",
-        "severity",
-        "status",
-        "column_break_core",
-        "party",
-        "party_secondary",
-        "score",
-        "section_break_reference",
-        "reference_doctype",
-        "reference_name",
-        "details_html",
-        "details_json",
-        "section_break_meta",
-        "source_engine",
-        "detected_on",
-        "resolved_on",
-        "resolved_by",
-        "dismiss_reason"
-    ],
-    "fields": [
-        {
-            "fieldname": "details_section",
-            "fieldtype": "Section Break",
-            "label": "Details"
-        },
-        {
-            "fieldname": "issue_type",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "in_standard_filter": 1,
-            "label": "Issue Type",
-            "options": "Duplicate\nUnlinked\nHealth\nTransaction Policy",
-            "reqd": 1,
-            "search_index": 1
-        },
-        {
-            "fieldname": "severity",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "in_standard_filter": 1,
-            "label": "Severity",
-            "options": "Low\nMedium\nHigh\nCritical",
-            "reqd": 1,
-            "search_index": 1
-        },
-        {
-            "default": "Open",
-            "fieldname": "status",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "in_standard_filter": 1,
-            "label": "Status",
-            "options": "Open\nUnder Review\nResolved\nIgnored",
-            "reqd": 1,
-            "search_index": 1
-        },
-        {
-            "fieldname": "column_break_core",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "party",
-            "fieldtype": "Link",
-            "in_list_view": 1,
-            "label": "Party",
-            "options": "Party Master",
-            "reqd": 1,
-            "search_index": 1
-        },
-        {
-            "fieldname": "party_secondary",
-            "fieldtype": "Link",
-            "label": "Secondary Party",
-            "options": "Party Master",
-            "search_index": 1
-        },
-        {
-            "fieldname": "score",
-            "fieldtype": "Float",
-            "label": "Score",
-            "precision": "2"
-        },
-        {
-            "fieldname": "section_break_reference",
-            "fieldtype": "Section Break",
-            "label": "Reference"
-        },
-        {
-            "fieldname": "reference_doctype",
-            "fieldtype": "Link",
-            "label": "Reference DocType",
-            "options": "DocType",
-            "search_index": 1
-        },
-        {
-            "fieldname": "reference_name",
-            "fieldtype": "Dynamic Link",
-            "label": "Reference Name",
-            "options": "reference_doctype",
-            "search_index": 1
-        },
-        {
-            "fieldname": "details_html",
-            "fieldtype": "HTML",
-            "label": "Details HTML"
-        },
-        {
-            "fieldname": "details_json",
-            "fieldtype": "Long Text",
-            "hidden": 1,
-            "label": "Details JSON"
-        },
-        {
-            "fieldname": "section_break_meta",
-            "fieldtype": "Section Break",
-            "label": "Metadata"
-        },
-        {
-            "fieldname": "source_engine",
-            "fieldtype": "Data",
-            "label": "Source Engine",
-            "search_index": 1
-        },
-        {
-            "fieldname": "detected_on",
-            "fieldtype": "Datetime",
-            "in_list_view": 1,
-            "label": "Detected On",
-            "read_only": 1
-        },
-        {
-            "fieldname": "resolved_on",
-            "fieldtype": "Datetime",
-            "label": "Resolved On",
-            "read_only": 1
-        },
-        {
-            "fieldname": "resolved_by",
-            "fieldtype": "Link",
-            "label": "Resolved By",
-            "options": "User",
-            "read_only": 1
-        },
-        {
-            "depends_on": "eval:doc.status=='Ignored'",
-            "fieldname": "dismiss_reason",
-            "fieldtype": "Small Text",
-            "label": "Dismiss Reason"
-        }
-    ],
-    "index_web_pages_for_search": 1,
-    "links": [],
-    "modified": "2026-02-20 22:15:00",
-    "modified_by": "Administrator",
-    "module": "Party",
-    "name": "Party Issue",
-    "owner": "Administrator",
-    "permissions": [
-        {
-            "create": 1,
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "System Manager",
-            "share": 1,
-            "write": 1
-        },
-        {
-            "create": 1,
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Party Manager",
-            "share": 1,
-            "write": 1
-        }
-    ],
-    "row_format": "Dynamic",
-    "sort_field": "detected_on",
-    "sort_order": "DESC",
-    "states": []
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-02-17 10:00:00",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "details_section",
+  "issue_type",
+  "severity",
+  "status",
+  "column_break_core",
+  "party",
+  "party_secondary",
+  "score",
+  "section_break_reference",
+  "reference_doctype",
+  "reference_name",
+  "details_html",
+  "details_json",
+  "section_break_meta",
+  "source_engine",
+  "detected_on",
+  "resolved_on",
+  "resolved_by",
+  "dismiss_reason"
+ ],
+ "fields": [
+  {
+   "fieldname": "details_section",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "issue_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Issue Type",
+   "options": "Duplicate\nUnlinked\nHealth\nTransaction Policy",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "severity",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Severity",
+   "options": "Low\nMedium\nHigh\nCritical",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "default": "Open",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Open\nUnder Review\nResolved\nIgnored",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_core",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "party",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Party",
+   "options": "Party Master",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "party_secondary",
+   "fieldtype": "Link",
+   "label": "Secondary Party",
+   "options": "Party Master",
+   "search_index": 1
+  },
+  {
+   "fieldname": "score",
+   "fieldtype": "Float",
+   "label": "Score",
+   "precision": "2"
+  },
+  {
+   "fieldname": "section_break_reference",
+   "fieldtype": "Section Break",
+   "label": "Reference"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference DocType",
+   "options": "DocType",
+   "search_index": 1
+  },
+  {
+   "fieldname": "reference_name",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference Name",
+   "options": "reference_doctype",
+   "search_index": 1
+  },
+  {
+   "fieldname": "details_html",
+   "fieldtype": "HTML",
+   "label": "Details HTML"
+  },
+  {
+   "fieldname": "details_json",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "label": "Details JSON"
+  },
+  {
+   "fieldname": "section_break_meta",
+   "fieldtype": "Section Break",
+   "label": "Metadata"
+  },
+  {
+   "fieldname": "source_engine",
+   "fieldtype": "Data",
+   "label": "Source Engine",
+   "search_index": 1
+  },
+  {
+   "fieldname": "detected_on",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Detected On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "resolved_on",
+   "fieldtype": "Datetime",
+   "label": "Resolved On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "resolved_by",
+   "fieldtype": "Link",
+   "label": "Resolved By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.status=='Ignored'",
+   "description": "Reason of Ignoring",
+   "fieldname": "dismiss_reason",
+   "fieldtype": "Small Text",
+   "label": "Dismiss Reason"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-02-21 01:39:34.496700",
+ "modified_by": "Administrator",
+ "module": "Party",
+ "name": "Party Issue",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Party Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "detected_on",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/uph/party/doctype/party_master/party_master.json
+++ b/uph/party/doctype/party_master/party_master.json
@@ -694,7 +694,7 @@
  "is_calendar_and_gantt": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2026-02-14 16:41:33.661915",
+ "modified": "2026-02-21 00:44:39.898174",
  "modified_by": "Administrator",
  "module": "Party",
  "name": "Party Master",
@@ -745,6 +745,18 @@
    "read": 1,
    "report": 1,
    "role": "Purchase Master Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Party Manager",
    "share": 1,
    "write": 1
   }

--- a/uph/party/doctype/party_master/party_master.py
+++ b/uph/party/doctype/party_master/party_master.py
@@ -29,23 +29,13 @@ class PartyMaster(NestedSet):
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from erpnext.accounts.doctype.allowed_to_transact_with.allowed_to_transact_with import (
-            AllowedToTransactWith,
-        )
-        from erpnext.selling.doctype.customer_credit_limit.customer_credit_limit import (
-            CustomerCreditLimit,
-        )
+        from erpnext.accounts.doctype.allowed_to_transact_with.allowed_to_transact_with import AllowedToTransactWith
+        from erpnext.selling.doctype.customer_credit_limit.customer_credit_limit import CustomerCreditLimit
         from erpnext.utilities.doctype.portal_user.portal_user import PortalUser
         from frappe.types import DF
-        from uph.party.doctype.party_master_accounts.party_master_accounts import (
-            PartyMasterAccounts,
-        )
-        from uph.party.doctype.party_master_parties.party_master_parties import (
-            PartyMasterParties,
-        )
-        from uph.party.doctype.party_master_role.party_master_role import (
-            PartyMasterRole,
-        )
+        from uph.party.doctype.party_master_accounts.party_master_accounts import PartyMasterAccounts
+        from uph.party.doctype.party_master_parties.party_master_parties import PartyMasterParties
+        from uph.party.doctype.party_master_role.party_master_role import PartyMasterRole
 
         account_manager: DF.Link | None
         accounts: DF.Table[PartyMasterAccounts]
@@ -71,24 +61,11 @@ class PartyMaster(NestedSet):
         is_internal_party: DF.Check
         is_primary_role: DF.Check
         language: DF.Link | None
-        legal_entity_type: DF.Literal[
-            "",
-            "Sole Proprietor",
-            "Partnership",
-            "Corporation",
-            "LLC",
-            "NGO",
-            "Freelancer",
-            "Government",
-            "Individual",
-            "Other",
-        ]
+        legal_entity_type: DF.Literal["", "Sole Proprietor", "Partnership", "Corporation", "LLC", "NGO", "Freelancer", "Government", "Individual", "Other"]
         lft: DF.Int
         market_segment: DF.Link | None
         mobile_no: DF.ReadOnly | None
-        naming_series: DF.Literal[
-            "{party_number}", ".{parent_party_master}.", "PM-{party_name}"
-        ]
+        naming_series: DF.Literal["{party_number}", ".{parent_party_master}.", "PM-{party_name}"]
         national_id: DF.Data | None
         normalized_party_name: DF.Data | None
         old_parent: DF.Link | None
@@ -110,21 +87,7 @@ class PartyMaster(NestedSet):
         rgt: DF.Int
         roles: DF.TableMultiSelect[PartyMasterRole]
         salutation: DF.Link | None
-        status: DF.Literal[
-            "Active",
-            "Disabled",
-            "Closed",
-            "Credit Hold",
-            "Delinquent",
-            "Disputed",
-            "Dormant",
-            "Write-Off",
-            "Approved",
-            "On Hold",
-            "Under Review",
-            "Terminated",
-            "Suspended",
-        ]
+        status: DF.Literal["Active", "Disabled", "Closed", "Credit Hold", "Delinquent", "Disputed", "Dormant", "Write-Off", "Approved", "On Hold", "Under Review", "Terminated", "Suspended"]
         tax_category: DF.Link | None
         tax_id: DF.Data | None
         tax_withholding_category: DF.Link | None

--- a/uph/party/doctype/party_master_settings/party_master_settings.js
+++ b/uph/party/doctype/party_master_settings/party_master_settings.js
@@ -40,16 +40,25 @@ frappe.ui.form.on("Party Master Settings", {
             if (!wrapper.find('.custom-table-description').length) {
                 wrapper.append(`
                     <div class="custom-table-description" 
-                        style="margin-top: 15px; padding: 15px; background-color: #f8f9fa; 
-                               border-radius: 3px; border: 1px solid #dfe3e6;">
-                        <h5 style="margin-bottom: 10px; color: #2e3b4a;">
-                            ${__('Configuration Rules')}
+                        style="margin-top: 15px; padding: 15px; background-color: #f8f9fa; border-left: 4px solid var(--blue-500);
+                               border-radius: 3px; border-top: 1px solid #dfe3e6; border-right: 1px solid #dfe3e6; border-bottom: 1px solid #dfe3e6;">
+                        <h5 style="margin-bottom: 5px; color: #2e3b4a; font-weight: 600;">
+                            <i class="fa fa-info-circle text-blue"></i> ${__('Understanding Document Types Configuration')}
                         </h5>
-                        <ul style="color: #4a5660; list-style: disc; padding-left: 25px;">
-                            <li>${__('Voucher Types must have a defined Party Master Field for validation')}</li>
-                            <li>${__('Child Document Types require explicit Parent Doctype configuration')}</li>
-                            <li>${__('System-generated Journal Entry Accounts bypass mandatory field checks')}</li>
-                            <li>${__('Parent Doctype fields auto-lock for non-child document types')}</li>
+                        <p style="color: var(--text-muted); font-size: 13px; margin-bottom: 10px;">
+                            ${__('This table defines which transactional DocTypes (like Sales Invoice or Journal Entry) the system will monitor to guarantee Data Quality and Party Master validation.')}
+                        </p>
+                        <h6 style="margin-bottom: 5px; color: #36414c; font-size: 13px; font-weight: 600;">${__('What you should set:')}</h6>
+                        <ul style="color: #4a5660; list-style: disc; padding-left: 25px; font-size: 12px; margin-bottom: 10px;">
+                            <li><b>${__('Document Type')}</b>: ${__('The exact voucher or child table to validate (e.g., Sales Invoice).')}</li>
+                            <li><b>${__('Parent Doctype')}</b>: ${__('If you add a Child Table (e.g., Journal Entry Account), select its Parent (e.g., Journal Entry).')}</li>
+                            <li><b>${__('Party Fieldname')}</b>: ${__('The field connecting to the Party (e.g., customer, party, supplier).')}</li>
+                            <li><b>${__('Party Type Fieldname')}</b>: ${__('Required if the Party Field is dynamic (e.g., party_type).')}</li>
+                        </ul>
+                        <h6 style="margin-bottom: 5px; color: #36414c; font-size: 13px; font-weight: 600;">${__('How it affects the system:')}</h6>
+                        <ul style="color: #4a5660; list-style: disc; padding-left: 25px; font-size: 12px; margin-bottom: 0;">
+                            <li>${__('<b>Data Quality Dashboard</b>: Documents configured here will be scanned for Missing Party Masters and Transaction Policy issues.')}</li>
+                            <li>${__('<b>Validation</b>: The system will automatically link the Party Master upon saving, or block transactions if the Party is invalid or missing.')}</li>
                         </ul>
                     </div>
                 `);

--- a/uph/party/doctype/party_master_settings/party_master_settings.json
+++ b/uph/party/doctype/party_master_settings/party_master_settings.json
@@ -1,332 +1,332 @@
 {
- "actions": [],
- "allow_rename": 1,
- "creation": "2025-04-05 17:27:20.040931",
- "doctype": "DocType",
- "documentation": "https://sendipad.github.io/uph/en/docs/introduction/Settings/",
- "engine": "InnoDB",
- "field_order": [
-  "general_configuration_section",
-  "override_party_details_api",
-  "column_break_qzjp",
-  "enforce_strict_currency",
-  "party_type_rules_section",
-  "party_types",
-  "doctype_fields_mapping_section",
-  "document_types",
-  "party_master_to_party_sync_fields_section",
-  "party_master_fields",
-  "governance_tab",
-  "numbering_section",
-  "numbering_format",
-  "column_break_gov1",
-  "digits_count",
-  "group_digits",
-  "governance_rules_section",
-  "enforce_parent_numbering",
-  "enforce_cross_type_uniqueness",
-  "column_break_gov2",
-  "sync_erp_party_naming",
-  "role_prefix_mode",
-  "transaction_policy_section",
-  "transaction_policy_draft_days",
-  "column_break_policy",
-  "transaction_policy_cancelled_reference_days",
-  "setup_section",
-  "setup_finished",
-  "column_break_gov3",
-  "party_master_tab",
-  "tree_view_section",
-  "auto_expand_levels",
-  "column_break_jote",
-  "hide_balance",
-  "paa_tab",
-  "enable_party_analytic_accounting",
-  "duplicate_voucher_configuration_tab",
-  "duplicate_check_section",
-  "check_party_master_duplicate_vouchers",
-  "duplicate_voucher_action",
-  "role_to_bypass_duplicate_voucher"
- ],
- "fields": [
-  {
-   "fieldname": "doctype_fields_mapping_section",
-   "fieldtype": "Section Break",
-   "label": "DocType Fields Mapping"
-  },
-  {
-   "fieldname": "document_types",
-   "fieldtype": "Table",
-   "label": "Document Types",
-   "options": "Party Master Settings DocType"
-  },
-  {
-   "fieldname": "duplicate_check_section",
-   "fieldtype": "Section Break",
-   "label": "Duplicate Voucher Configuration"
-  },
-  {
-   "default": "1",
-   "fieldname": "check_party_master_duplicate_vouchers",
-   "fieldtype": "Check",
-   "label": "Check Party Master Duplicate Vouchers"
-  },
-  {
-   "default": "Warn",
-   "depends_on": "check_party_master_duplicate_vouchers",
-   "fieldname": "duplicate_voucher_action",
-   "fieldtype": "Select",
-   "label": "Duplicate Voucher Action",
-   "options": "Warn\nStop"
-  },
-  {
-   "depends_on": "check_party_master_duplicate_vouchers",
-   "fieldname": "role_to_bypass_duplicate_voucher",
-   "fieldtype": "Link",
-   "label": "Role to Bypass Duplicate Voucher Check",
-   "options": "Role"
-  },
-  {
-   "fieldname": "party_master_to_party_sync_fields_section",
-   "fieldtype": "Section Break",
-   "label": "Party Master To Party Sync Fields"
-  },
-  {
-   "fieldname": "party_master_fields",
-   "fieldtype": "Table",
-   "label": "Party Master Fields",
-   "options": "Party Master Settings DocField"
-  },
-  {
-   "fieldname": "party_type_rules_section",
-   "fieldtype": "Section Break",
-   "label": "Party Type Rules"
-  },
-  {
-   "fieldname": "party_types",
-   "fieldtype": "Table",
-   "label": "Party Types",
-   "options": "Party Master Settings Party Type"
-  },
-  {
-   "fieldname": "party_master_tab",
-   "fieldtype": "Tab Break",
-   "label": "Party Master"
-  },
-  {
-   "default": "4",
-   "fieldname": "auto_expand_levels",
-   "fieldtype": "Int",
-   "label": "Party Master Tree View Expand Lvele"
-  },
-  {
-   "fieldname": "column_break_jote",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "tree_view_section",
-   "fieldtype": "Section Break",
-   "label": "Tree View"
-  },
-  {
-   "default": "1",
-   "fieldname": "hide_balance",
-   "fieldtype": "Check",
-   "label": "Hide Balance in Tree"
-  },
-  {
-   "default": "1",
-   "fieldname": "override_party_details_api",
-   "fieldtype": "Check",
-   "label": "Override Party Details API "
-  },
-  {
-   "fieldname": "column_break_qzjp",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "1",
-   "description": "Enable to enforce strict currency mapping document's currency to accounts head currency.",
-   "fieldname": "enforce_strict_currency",
-   "fieldtype": "Check",
-   "label": "Enforce Strict Currency Accounting"
-  },
-  {
-   "fieldname": "general_configuration_section",
-   "fieldtype": "Section Break",
-   "label": "General Configuration"
-  },
-  {
-   "default": "1",
-   "fieldname": "paa_tab",
-   "fieldtype": "Tab Break",
-   "label": "PAA"
-  },
-  {
-   "default": "0",
-   "fieldname": "enable_party_analytic_accounting",
-   "fieldtype": "Check",
-   "label": "Enable Party Analytic Accounting"
-  },
-  {
-   "fieldname": "duplicate_voucher_configuration_tab",
-   "fieldtype": "Tab Break",
-   "label": "Duplicate Voucher Configuration"
-  },
-  {
-   "fieldname": "governance_tab",
-   "fieldtype": "Tab Break",
-   "label": "Governance"
-  },
-  {
-   "fieldname": "numbering_section",
-   "fieldtype": "Section Break",
-   "label": "Numbering"
-  },
-  {
-   "default": "Concatenated",
-   "description": "Choose how party numbers are formatted. Concatenated: 1000000001. Dash-Separated: 1000-000001.",
-   "fieldname": "numbering_format",
-   "fieldtype": "Select",
-   "label": "Numbering Format",
-   "options": "Concatenated\nDash-Separated"
-  },
-  {
-   "fieldname": "column_break_gov1",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "6",
-   "description": "Number of digits for the leaf party suffix (e.g. 6 means 000001\u2013999999 under each group).",
-   "fieldname": "digits_count",
-   "fieldtype": "Int",
-   "label": "Leaf Digits Count",
-   "non_negative": 1
-  },
-  {
-   "default": "4",
-   "description": "Number of digits for group party nodes (e.g. 4 means 1000\u20139999).",
-   "fieldname": "group_digits",
-   "fieldtype": "Int",
-   "label": "Group Digits Count",
-   "non_negative": 1
-  },
-  {
-   "fieldname": "governance_rules_section",
-   "fieldtype": "Section Break",
-   "label": "Governance Rules"
-  },
-  {
-   "fieldname": "transaction_policy_section",
-   "fieldtype": "Section Break",
-   "label": "Transaction Policy"
-  },
-  {
-   "default": "30",
-   "description": "Create a Party Issue when a draft voucher is older than this many days.",
-   "fieldname": "transaction_policy_draft_days",
-   "fieldtype": "Int",
-   "label": "Draft Issue Threshold (Days)",
-   "non_negative": 1
-  },
-  {
-   "fieldname": "column_break_policy",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "description": "Grace period before flagging cancelled vouchers still referenced in financial flow. 0 = no grace.",
-   "fieldname": "transaction_policy_cancelled_reference_days",
-   "fieldtype": "Int",
-   "label": "Cancelled Reference Grace (Days)",
-   "non_negative": 1
-  },
-  {
-   "default": "0",
-   "description": "Enforce that child party numbers start with the parent group's prefix.",
-   "fieldname": "enforce_parent_numbering",
-   "fieldtype": "Check",
-   "label": "Enforce Parent Numbering Prefix"
-  },
-  {
-   "default": "0",
-   "description": "Prevent the same party (e.g. same Customer) from being linked to multiple Party Masters.",
-   "fieldname": "enforce_cross_type_uniqueness",
-   "fieldtype": "Check",
-   "label": "Enforce Cross-Type Uniqueness"
-  },
-  {
-   "fieldname": "column_break_gov2",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "description": "Sync ERPNext party record names with Party Master numbering.",
-   "fieldname": "sync_erp_party_naming",
-   "fieldtype": "Check",
-   "label": "Sync ERP Party Naming"
-  },
-  {
-   "default": "Prefix for All Role",
-   "depends_on": "sync_erp_party_naming",
-   "description": "How to incorporate the role type into the party name.",
-   "fieldname": "role_prefix_mode",
-   "fieldtype": "Select",
-   "label": "Role Prefix Mode",
-   "options": "Prefix for All Role\nPrefix for Secondary Role\nSuffix for All Role\nSuffix Secondary Roles"
-  },
-  {
-   "fieldname": "setup_section",
-   "fieldtype": "Section Break",
-   "label": "Setup"
-  },
-  {
-   "default": "0",
-   "description": "Once checked, core governance settings (Numbering Format, Digits Count) become read-only to prevent accidental changes in production.",
-   "fieldname": "setup_finished",
-   "fieldtype": "Check",
-   "label": "Setup Finished",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_gov3",
-   "fieldtype": "Column Break"
-  }
- ],
- "grid_page_length": 50,
- "index_web_pages_for_search": 1,
- "issingle": 1,
- "links": [],
- "modified": "2026-02-21 00:43:09.276049",
- "modified_by": "Administrator",
- "module": "Party",
- "name": "Party Master Settings",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "role": "Party Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "row_format": "Dynamic",
- "rows_threshold_for_grid_search": 20,
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+    "actions": [],
+    "allow_rename": 1,
+    "creation": "2025-04-05 17:27:20.040931",
+    "doctype": "DocType",
+    "documentation": "https://sendipad.github.io/uph/en/docs/introduction/Settings/",
+    "engine": "InnoDB",
+    "field_order": [
+        "general_configuration_section",
+        "override_party_details_api",
+        "column_break_qzjp",
+        "enforce_strict_currency",
+        "party_type_rules_section",
+        "party_types",
+        "doctype_fields_mapping_section",
+        "document_types",
+        "party_master_to_party_sync_fields_section",
+        "party_master_fields",
+        "governance_tab",
+        "numbering_section",
+        "numbering_format",
+        "column_break_gov1",
+        "digits_count",
+        "group_digits",
+        "governance_rules_section",
+        "enforce_parent_numbering",
+        "enforce_cross_type_uniqueness",
+        "column_break_gov2",
+        "sync_erp_party_naming",
+        "role_prefix_mode",
+        "transaction_policy_section",
+        "transaction_policy_draft_days",
+        "column_break_policy",
+        "transaction_policy_cancelled_reference_days",
+        "setup_section",
+        "setup_finished",
+        "column_break_gov3",
+        "party_master_tab",
+        "tree_view_section",
+        "auto_expand_levels",
+        "column_break_jote",
+        "hide_balance",
+        "paa_tab",
+        "enable_party_analytic_accounting",
+        "duplicate_voucher_configuration_tab",
+        "duplicate_check_section",
+        "check_party_master_duplicate_vouchers",
+        "duplicate_voucher_action",
+        "role_to_bypass_duplicate_voucher"
+    ],
+    "fields": [
+        {
+            "fieldname": "doctype_fields_mapping_section",
+            "fieldtype": "Section Break",
+            "label": "DocType Fields Mapping"
+        },
+        {
+            "fieldname": "document_types",
+            "fieldtype": "Table",
+            "label": "Document Types",
+            "options": "Party Master Settings DocType"
+        },
+        {
+            "fieldname": "duplicate_check_section",
+            "fieldtype": "Section Break",
+            "label": "Duplicate Voucher Configuration"
+        },
+        {
+            "default": "1",
+            "fieldname": "check_party_master_duplicate_vouchers",
+            "fieldtype": "Check",
+            "label": "Check Party Master Duplicate Vouchers"
+        },
+        {
+            "default": "Warn",
+            "depends_on": "check_party_master_duplicate_vouchers",
+            "fieldname": "duplicate_voucher_action",
+            "fieldtype": "Select",
+            "label": "Duplicate Voucher Action",
+            "options": "Warn\nStop"
+        },
+        {
+            "depends_on": "check_party_master_duplicate_vouchers",
+            "fieldname": "role_to_bypass_duplicate_voucher",
+            "fieldtype": "Link",
+            "label": "Role to Bypass Duplicate Voucher Check",
+            "options": "Role"
+        },
+        {
+            "fieldname": "party_master_to_party_sync_fields_section",
+            "fieldtype": "Section Break",
+            "label": "Party Master To Party Sync Fields"
+        },
+        {
+            "fieldname": "party_master_fields",
+            "fieldtype": "Table",
+            "label": "Party Master Fields",
+            "options": "Party Master Settings DocField"
+        },
+        {
+            "fieldname": "party_type_rules_section",
+            "fieldtype": "Section Break",
+            "label": "Party Type Rules"
+        },
+        {
+            "fieldname": "party_types",
+            "fieldtype": "Table",
+            "label": "Party Types",
+            "options": "Party Master Settings Party Type"
+        },
+        {
+            "fieldname": "party_master_tab",
+            "fieldtype": "Tab Break",
+            "label": "Party Master"
+        },
+        {
+            "default": "4",
+            "fieldname": "auto_expand_levels",
+            "fieldtype": "Int",
+            "label": "Party Master Tree View Expand Lvele"
+        },
+        {
+            "fieldname": "column_break_jote",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "tree_view_section",
+            "fieldtype": "Section Break",
+            "label": "Tree View"
+        },
+        {
+            "default": "1",
+            "fieldname": "hide_balance",
+            "fieldtype": "Check",
+            "label": "Hide Balance in Tree"
+        },
+        {
+            "default": "1",
+            "fieldname": "override_party_details_api",
+            "fieldtype": "Check",
+            "label": "Override Party Details API "
+        },
+        {
+            "fieldname": "column_break_qzjp",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "1",
+            "description": "Enable to enforce strict currency mapping document's currency to accounts head currency.",
+            "fieldname": "enforce_strict_currency",
+            "fieldtype": "Check",
+            "label": "Enforce Strict Currency Accounting"
+        },
+        {
+            "fieldname": "general_configuration_section",
+            "fieldtype": "Section Break",
+            "label": "General Configuration"
+        },
+        {
+            "default": "1",
+            "fieldname": "paa_tab",
+            "fieldtype": "Tab Break",
+            "label": "PAA"
+        },
+        {
+            "default": "0",
+            "fieldname": "enable_party_analytic_accounting",
+            "fieldtype": "Check",
+            "label": "Enable Party Analytic Accounting"
+        },
+        {
+            "fieldname": "duplicate_voucher_configuration_tab",
+            "fieldtype": "Tab Break",
+            "label": "Duplicate Voucher Configuration"
+        },
+        {
+            "fieldname": "governance_tab",
+            "fieldtype": "Tab Break",
+            "label": "Governance"
+        },
+        {
+            "fieldname": "numbering_section",
+            "fieldtype": "Section Break",
+            "label": "Numbering"
+        },
+        {
+            "default": "Concatenated",
+            "description": "Choose how party numbers are formatted. Concatenated: 1000000001. Dash-Separated: 1000-000001.",
+            "fieldname": "numbering_format",
+            "fieldtype": "Select",
+            "label": "Numbering Format",
+            "options": "Concatenated\nDash-Separated"
+        },
+        {
+            "fieldname": "column_break_gov1",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "6",
+            "description": "Number of digits for the leaf party suffix (e.g. 6 means 000001\u2013999999 under each group).",
+            "fieldname": "digits_count",
+            "fieldtype": "Int",
+            "label": "Leaf Digits Count",
+            "non_negative": 1
+        },
+        {
+            "default": "4",
+            "description": "Number of digits for group party nodes (e.g. 4 means 1000\u20139999).",
+            "fieldname": "group_digits",
+            "fieldtype": "Int",
+            "label": "Group Digits Count",
+            "non_negative": 1
+        },
+        {
+            "fieldname": "governance_rules_section",
+            "fieldtype": "Section Break",
+            "label": "Governance Rules"
+        },
+        {
+            "fieldname": "transaction_policy_section",
+            "fieldtype": "Section Break",
+            "label": "Transaction Policy"
+        },
+        {
+            "default": "30",
+            "description": "Create a Party Issue when a draft voucher is older than this many days.",
+            "fieldname": "transaction_policy_draft_days",
+            "fieldtype": "Int",
+            "label": "Draft Issue Threshold (Days)",
+            "non_negative": 1
+        },
+        {
+            "fieldname": "column_break_policy",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "0",
+            "description": "Grace period before flagging cancelled vouchers still referenced in financial flow. 0 = no grace.",
+            "fieldname": "transaction_policy_cancelled_reference_days",
+            "fieldtype": "Int",
+            "label": "Cancelled Reference Grace (Days)",
+            "non_negative": 1
+        },
+        {
+            "default": "0",
+            "description": "Enforce that child party numbers start with the parent group's prefix.",
+            "fieldname": "enforce_parent_numbering",
+            "fieldtype": "Check",
+            "label": "Enforce Parent Numbering Prefix"
+        },
+        {
+            "default": "0",
+            "description": "Enforce unique naming across all Party Types (e.g. cannot have a Customer and Supplier with the exact same Name).",
+            "fieldname": "enforce_cross_type_uniqueness",
+            "fieldtype": "Check",
+            "label": "Enforce Cross-Type Naming Uniqueness"
+        },
+        {
+            "fieldname": "column_break_gov2",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "0",
+            "description": "Sync ERPNext party record names with Party Master numbering.",
+            "fieldname": "sync_erp_party_naming",
+            "fieldtype": "Check",
+            "label": "Sync ERP Party Naming"
+        },
+        {
+            "default": "Prefix for All Role",
+            "depends_on": "eval:doc.sync_erp_party_naming == 1",
+            "description": "Applies a 2-letter abbreviation of the Party Type (e.g. 'Cu' for Customer, 'Su' for Supplier) as a prefix/suffix to the party name.",
+            "fieldname": "role_prefix_mode",
+            "fieldtype": "Select",
+            "label": "Role Prefix Mode",
+            "options": "Prefix for All Role\nPrefix for Secondary Role\nSuffix for All Role\nSuffix Secondary Roles"
+        },
+        {
+            "fieldname": "setup_section",
+            "fieldtype": "Section Break",
+            "label": "Setup"
+        },
+        {
+            "default": "0",
+            "description": "Once checked, core governance settings (Numbering Format, Digits Count) become read-only to prevent accidental changes in production.",
+            "fieldname": "setup_finished",
+            "fieldtype": "Check",
+            "label": "Setup Finished",
+            "read_only": 1
+        },
+        {
+            "fieldname": "column_break_gov3",
+            "fieldtype": "Column Break"
+        }
+    ],
+    "grid_page_length": 50,
+    "index_web_pages_for_search": 1,
+    "issingle": 1,
+    "links": [],
+    "modified": "2026-02-21 00:43:09.276049",
+    "modified_by": "Administrator",
+    "module": "Party",
+    "name": "Party Master Settings",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "print": 1,
+            "read": 1,
+            "role": "System Manager",
+            "share": 1,
+            "write": 1
+        },
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "print": 1,
+            "read": 1,
+            "role": "Party Manager",
+            "share": 1,
+            "write": 1
+        }
+    ],
+    "row_format": "Dynamic",
+    "rows_threshold_for_grid_search": 20,
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
 }

--- a/uph/party/doctype/party_master_settings/party_master_settings.json
+++ b/uph/party/doctype/party_master_settings/party_master_settings.json
@@ -268,7 +268,7 @@
         },
         {
             "default": "Prefix for All Role",
-            "depends_on": "eval:doc.sync_erp_party_naming == 1",
+            "depends_on": "sync_erp_party_naming",
             "description": "Applies a 2-letter abbreviation of the Party Type (e.g. 'Cu' for Customer, 'Su' for Supplier) as a prefix/suffix to the party name.",
             "fieldname": "role_prefix_mode",
             "fieldtype": "Select",

--- a/uph/party/doctype/party_master_settings/party_master_settings.json
+++ b/uph/party/doctype/party_master_settings/party_master_settings.json
@@ -1,323 +1,332 @@
 {
-    "actions": [],
-    "allow_rename": 1,
-    "creation": "2025-04-05 17:27:20.040931",
-    "doctype": "DocType",
-    "documentation": "https://sendipad.github.io/uph/en/docs/introduction/Settings/",
-    "engine": "InnoDB",
-    "field_order": [
-        "general_configuration_section",
-        "override_party_details_api",
-        "column_break_qzjp",
-        "enforce_strict_currency",
-        "party_type_rules_section",
-        "party_types",
-        "doctype_fields_mapping_section",
-        "document_types",
-        "party_master_to_party_sync_fields_section",
-        "party_master_fields",
-        "governance_tab",
-        "numbering_section",
-        "numbering_format",
-        "column_break_gov1",
-        "digits_count",
-        "group_digits",
-        "governance_rules_section",
-        "enforce_parent_numbering",
-        "enforce_cross_type_uniqueness",
-        "column_break_gov2",
-        "sync_erp_party_naming",
-        "role_prefix_mode",
-        "transaction_policy_section",
-        "transaction_policy_draft_days",
-        "column_break_policy",
-        "transaction_policy_cancelled_reference_days",
-        "setup_section",
-        "setup_finished",
-        "column_break_gov3",
-        "language",
-        "party_master_tab",
-        "tree_view_section",
-        "auto_expand_levels",
-        "column_break_jote",
-        "hide_balance",
-        "paa_tab",
-        "enable_party_analytic_accounting",
-        "duplicate_voucher_configuration_tab",
-        "duplicate_check_section",
-        "check_party_master_duplicate_vouchers",
-        "duplicate_voucher_action",
-        "role_to_bypass_duplicate_voucher"
-    ],
-    "fields": [
-        {
-            "fieldname": "doctype_fields_mapping_section",
-            "fieldtype": "Section Break",
-            "label": "DocType Fields Mapping"
-        },
-        {
-            "fieldname": "document_types",
-            "fieldtype": "Table",
-            "label": "Document Types",
-            "options": "Party Master Settings DocType"
-        },
-        {
-            "fieldname": "duplicate_check_section",
-            "fieldtype": "Section Break",
-            "label": "Duplicate Voucher Configuration"
-        },
-        {
-            "default": "1",
-            "fieldname": "check_party_master_duplicate_vouchers",
-            "fieldtype": "Check",
-            "label": "Check Party Master Duplicate Vouchers"
-        },
-        {
-            "default": "Warn",
-            "depends_on": "check_party_master_duplicate_vouchers",
-            "fieldname": "duplicate_voucher_action",
-            "fieldtype": "Select",
-            "label": "Duplicate Voucher Action",
-            "options": "Warn\nStop"
-        },
-        {
-            "depends_on": "check_party_master_duplicate_vouchers",
-            "fieldname": "role_to_bypass_duplicate_voucher",
-            "fieldtype": "Link",
-            "label": "Role to Bypass Duplicate Voucher Check",
-            "options": "Role"
-        },
-        {
-            "fieldname": "party_master_to_party_sync_fields_section",
-            "fieldtype": "Section Break",
-            "label": "Party Master To Party Sync Fields"
-        },
-        {
-            "fieldname": "party_master_fields",
-            "fieldtype": "Table",
-            "label": "Party Master Fields",
-            "options": "Party Master Settings DocField"
-        },
-        {
-            "fieldname": "party_type_rules_section",
-            "fieldtype": "Section Break",
-            "label": "Party Type Rules"
-        },
-        {
-            "fieldname": "party_types",
-            "fieldtype": "Table",
-            "label": "Party Types",
-            "options": "Party Master Settings Party Type"
-        },
-        {
-            "fieldname": "party_master_tab",
-            "fieldtype": "Tab Break",
-            "label": "Party Master"
-        },
-        {
-            "default": "4",
-            "fieldname": "auto_expand_levels",
-            "fieldtype": "Int",
-            "label": "Party Master Tree View Expand Lvele"
-        },
-        {
-            "fieldname": "column_break_jote",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "tree_view_section",
-            "fieldtype": "Section Break",
-            "label": "Tree View"
-        },
-        {
-            "default": "1",
-            "fieldname": "hide_balance",
-            "fieldtype": "Check",
-            "label": "Hide Balance in Tree"
-        },
-        {
-            "default": "1",
-            "fieldname": "override_party_details_api",
-            "fieldtype": "Check",
-            "label": "Override Party Details API "
-        },
-        {
-            "fieldname": "column_break_qzjp",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "1",
-            "description": "Enable to enforce strict currency mapping document's currency to accounts head currency.",
-            "fieldname": "enforce_strict_currency",
-            "fieldtype": "Check",
-            "label": "Enforce Strict Currency Accounting"
-        },
-        {
-            "fieldname": "general_configuration_section",
-            "fieldtype": "Section Break",
-            "label": "General Configuration"
-        },
-        {
-            "default": "1",
-            "fieldname": "paa_tab",
-            "fieldtype": "Tab Break",
-            "label": "PAA"
-        },
-        {
-            "default": "0",
-            "fieldname": "enable_party_analytic_accounting",
-            "fieldtype": "Check",
-            "label": "Enable Party Analytic Accounting"
-        },
-        {
-            "fieldname": "duplicate_voucher_configuration_tab",
-            "fieldtype": "Tab Break",
-            "label": "Duplicate Voucher Configuration"
-        },
-        {
-            "fieldname": "governance_tab",
-            "fieldtype": "Tab Break",
-            "label": "Governance"
-        },
-        {
-            "fieldname": "numbering_section",
-            "fieldtype": "Section Break",
-            "label": "Numbering"
-        },
-        {
-            "default": "Concatenated",
-            "description": "Choose how party numbers are formatted. Concatenated: 1000000001. Dash-Separated: 1000-000001.",
-            "fieldname": "numbering_format",
-            "fieldtype": "Select",
-            "label": "Numbering Format",
-            "options": "Concatenated\nDash-Separated"
-        },
-        {
-            "fieldname": "column_break_gov1",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "6",
-            "description": "Number of digits for the leaf party suffix (e.g. 6 means 000001\u2013999999 under each group).",
-            "fieldname": "digits_count",
-            "fieldtype": "Int",
-            "label": "Leaf Digits Count",
-            "non_negative": 1
-        },
-        {
-            "default": "4",
-            "description": "Number of digits for group party nodes (e.g. 4 means 1000\u20139999).",
-            "fieldname": "group_digits",
-            "fieldtype": "Int",
-            "label": "Group Digits Count",
-            "non_negative": 1
-        },
-        {
-            "fieldname": "governance_rules_section",
-            "fieldtype": "Section Break",
-            "label": "Governance Rules"
-        },
-        {
-            "fieldname": "transaction_policy_section",
-            "fieldtype": "Section Break",
-            "label": "Transaction Policy"
-        },
-        {
-            "default": "30",
-            "fieldname": "transaction_policy_draft_days",
-            "fieldtype": "Int",
-            "label": "Draft Issue Threshold (Days)",
-            "description": "Create a Party Issue when a draft voucher is older than this many days.",
-            "non_negative": 1
-        },
-        {
-            "fieldname": "column_break_policy",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "0",
-            "fieldname": "transaction_policy_cancelled_reference_days",
-            "fieldtype": "Int",
-            "label": "Cancelled Reference Grace (Days)",
-            "description": "Grace period before flagging cancelled vouchers still referenced in financial flow. 0 = no grace.",
-            "non_negative": 1
-        },
-        {
-            "default": "0",
-            "description": "Enforce that child party numbers start with the parent group's prefix.",
-            "fieldname": "enforce_parent_numbering",
-            "fieldtype": "Check",
-            "label": "Enforce Parent Numbering Prefix"
-        },
-        {
-            "default": "0",
-            "description": "Prevent the same party (e.g. same Customer) from being linked to multiple Party Masters.",
-            "fieldname": "enforce_cross_type_uniqueness",
-            "fieldtype": "Check",
-            "label": "Enforce Cross-Type Uniqueness"
-        },
-        {
-            "fieldname": "column_break_gov2",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "0",
-            "description": "Sync ERPNext party record names with Party Master numbering.",
-            "fieldname": "sync_erp_party_naming",
-            "fieldtype": "Check",
-            "label": "Sync ERP Party Naming"
-        },
-        {
-            "default": "Prefix for All Role",
-            "depends_on": "sync_erp_party_naming",
-            "description": "How to incorporate the role type into the party name.",
-            "fieldname": "role_prefix_mode",
-            "fieldtype": "Select",
-            "label": "Role Prefix Mode",
-            "options": "Prefix for All Role\nPrefix for Secondary Role\nSuffix for All Role\nSuffix Secondary Roles"
-        },
-        {
-            "fieldname": "setup_section",
-            "fieldtype": "Section Break",
-            "label": "Setup"
-        },
-        {
-            "default": "0",
-            "description": "Once checked, core governance settings (Numbering Format, Digits Count) become read-only to prevent accidental changes in production.",
-            "fieldname": "setup_finished",
-            "fieldtype": "Check",
-            "label": "Setup Finished",
-            "read_only": 1
-        },
-        {
-            "fieldname": "column_break_gov3",
-            "fieldtype": "Column Break"
-        }
-    ],
-    "grid_page_length": 50,
-    "index_web_pages_for_search": 1,
-    "issingle": 1,
-    "links": [],
-    "modified": "2026-02-16 16:11:59.652289",
-    "modified_by": "Administrator",
-    "module": "Party",
-    "name": "Party Master Settings",
-    "owner": "Administrator",
-    "permissions": [
-        {
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "print": 1,
-            "read": 1,
-            "role": "System Manager",
-            "share": 1,
-            "write": 1
-        }
-    ],
-    "row_format": "Dynamic",
-    "rows_threshold_for_grid_search": 20,
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": []
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-04-05 17:27:20.040931",
+ "doctype": "DocType",
+ "documentation": "https://sendipad.github.io/uph/en/docs/introduction/Settings/",
+ "engine": "InnoDB",
+ "field_order": [
+  "general_configuration_section",
+  "override_party_details_api",
+  "column_break_qzjp",
+  "enforce_strict_currency",
+  "party_type_rules_section",
+  "party_types",
+  "doctype_fields_mapping_section",
+  "document_types",
+  "party_master_to_party_sync_fields_section",
+  "party_master_fields",
+  "governance_tab",
+  "numbering_section",
+  "numbering_format",
+  "column_break_gov1",
+  "digits_count",
+  "group_digits",
+  "governance_rules_section",
+  "enforce_parent_numbering",
+  "enforce_cross_type_uniqueness",
+  "column_break_gov2",
+  "sync_erp_party_naming",
+  "role_prefix_mode",
+  "transaction_policy_section",
+  "transaction_policy_draft_days",
+  "column_break_policy",
+  "transaction_policy_cancelled_reference_days",
+  "setup_section",
+  "setup_finished",
+  "column_break_gov3",
+  "party_master_tab",
+  "tree_view_section",
+  "auto_expand_levels",
+  "column_break_jote",
+  "hide_balance",
+  "paa_tab",
+  "enable_party_analytic_accounting",
+  "duplicate_voucher_configuration_tab",
+  "duplicate_check_section",
+  "check_party_master_duplicate_vouchers",
+  "duplicate_voucher_action",
+  "role_to_bypass_duplicate_voucher"
+ ],
+ "fields": [
+  {
+   "fieldname": "doctype_fields_mapping_section",
+   "fieldtype": "Section Break",
+   "label": "DocType Fields Mapping"
+  },
+  {
+   "fieldname": "document_types",
+   "fieldtype": "Table",
+   "label": "Document Types",
+   "options": "Party Master Settings DocType"
+  },
+  {
+   "fieldname": "duplicate_check_section",
+   "fieldtype": "Section Break",
+   "label": "Duplicate Voucher Configuration"
+  },
+  {
+   "default": "1",
+   "fieldname": "check_party_master_duplicate_vouchers",
+   "fieldtype": "Check",
+   "label": "Check Party Master Duplicate Vouchers"
+  },
+  {
+   "default": "Warn",
+   "depends_on": "check_party_master_duplicate_vouchers",
+   "fieldname": "duplicate_voucher_action",
+   "fieldtype": "Select",
+   "label": "Duplicate Voucher Action",
+   "options": "Warn\nStop"
+  },
+  {
+   "depends_on": "check_party_master_duplicate_vouchers",
+   "fieldname": "role_to_bypass_duplicate_voucher",
+   "fieldtype": "Link",
+   "label": "Role to Bypass Duplicate Voucher Check",
+   "options": "Role"
+  },
+  {
+   "fieldname": "party_master_to_party_sync_fields_section",
+   "fieldtype": "Section Break",
+   "label": "Party Master To Party Sync Fields"
+  },
+  {
+   "fieldname": "party_master_fields",
+   "fieldtype": "Table",
+   "label": "Party Master Fields",
+   "options": "Party Master Settings DocField"
+  },
+  {
+   "fieldname": "party_type_rules_section",
+   "fieldtype": "Section Break",
+   "label": "Party Type Rules"
+  },
+  {
+   "fieldname": "party_types",
+   "fieldtype": "Table",
+   "label": "Party Types",
+   "options": "Party Master Settings Party Type"
+  },
+  {
+   "fieldname": "party_master_tab",
+   "fieldtype": "Tab Break",
+   "label": "Party Master"
+  },
+  {
+   "default": "4",
+   "fieldname": "auto_expand_levels",
+   "fieldtype": "Int",
+   "label": "Party Master Tree View Expand Lvele"
+  },
+  {
+   "fieldname": "column_break_jote",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "tree_view_section",
+   "fieldtype": "Section Break",
+   "label": "Tree View"
+  },
+  {
+   "default": "1",
+   "fieldname": "hide_balance",
+   "fieldtype": "Check",
+   "label": "Hide Balance in Tree"
+  },
+  {
+   "default": "1",
+   "fieldname": "override_party_details_api",
+   "fieldtype": "Check",
+   "label": "Override Party Details API "
+  },
+  {
+   "fieldname": "column_break_qzjp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "description": "Enable to enforce strict currency mapping document's currency to accounts head currency.",
+   "fieldname": "enforce_strict_currency",
+   "fieldtype": "Check",
+   "label": "Enforce Strict Currency Accounting"
+  },
+  {
+   "fieldname": "general_configuration_section",
+   "fieldtype": "Section Break",
+   "label": "General Configuration"
+  },
+  {
+   "default": "1",
+   "fieldname": "paa_tab",
+   "fieldtype": "Tab Break",
+   "label": "PAA"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_party_analytic_accounting",
+   "fieldtype": "Check",
+   "label": "Enable Party Analytic Accounting"
+  },
+  {
+   "fieldname": "duplicate_voucher_configuration_tab",
+   "fieldtype": "Tab Break",
+   "label": "Duplicate Voucher Configuration"
+  },
+  {
+   "fieldname": "governance_tab",
+   "fieldtype": "Tab Break",
+   "label": "Governance"
+  },
+  {
+   "fieldname": "numbering_section",
+   "fieldtype": "Section Break",
+   "label": "Numbering"
+  },
+  {
+   "default": "Concatenated",
+   "description": "Choose how party numbers are formatted. Concatenated: 1000000001. Dash-Separated: 1000-000001.",
+   "fieldname": "numbering_format",
+   "fieldtype": "Select",
+   "label": "Numbering Format",
+   "options": "Concatenated\nDash-Separated"
+  },
+  {
+   "fieldname": "column_break_gov1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "6",
+   "description": "Number of digits for the leaf party suffix (e.g. 6 means 000001\u2013999999 under each group).",
+   "fieldname": "digits_count",
+   "fieldtype": "Int",
+   "label": "Leaf Digits Count",
+   "non_negative": 1
+  },
+  {
+   "default": "4",
+   "description": "Number of digits for group party nodes (e.g. 4 means 1000\u20139999).",
+   "fieldname": "group_digits",
+   "fieldtype": "Int",
+   "label": "Group Digits Count",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "governance_rules_section",
+   "fieldtype": "Section Break",
+   "label": "Governance Rules"
+  },
+  {
+   "fieldname": "transaction_policy_section",
+   "fieldtype": "Section Break",
+   "label": "Transaction Policy"
+  },
+  {
+   "default": "30",
+   "description": "Create a Party Issue when a draft voucher is older than this many days.",
+   "fieldname": "transaction_policy_draft_days",
+   "fieldtype": "Int",
+   "label": "Draft Issue Threshold (Days)",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "column_break_policy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Grace period before flagging cancelled vouchers still referenced in financial flow. 0 = no grace.",
+   "fieldname": "transaction_policy_cancelled_reference_days",
+   "fieldtype": "Int",
+   "label": "Cancelled Reference Grace (Days)",
+   "non_negative": 1
+  },
+  {
+   "default": "0",
+   "description": "Enforce that child party numbers start with the parent group's prefix.",
+   "fieldname": "enforce_parent_numbering",
+   "fieldtype": "Check",
+   "label": "Enforce Parent Numbering Prefix"
+  },
+  {
+   "default": "0",
+   "description": "Prevent the same party (e.g. same Customer) from being linked to multiple Party Masters.",
+   "fieldname": "enforce_cross_type_uniqueness",
+   "fieldtype": "Check",
+   "label": "Enforce Cross-Type Uniqueness"
+  },
+  {
+   "fieldname": "column_break_gov2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Sync ERPNext party record names with Party Master numbering.",
+   "fieldname": "sync_erp_party_naming",
+   "fieldtype": "Check",
+   "label": "Sync ERP Party Naming"
+  },
+  {
+   "default": "Prefix for All Role",
+   "depends_on": "sync_erp_party_naming",
+   "description": "How to incorporate the role type into the party name.",
+   "fieldname": "role_prefix_mode",
+   "fieldtype": "Select",
+   "label": "Role Prefix Mode",
+   "options": "Prefix for All Role\nPrefix for Secondary Role\nSuffix for All Role\nSuffix Secondary Roles"
+  },
+  {
+   "fieldname": "setup_section",
+   "fieldtype": "Section Break",
+   "label": "Setup"
+  },
+  {
+   "default": "0",
+   "description": "Once checked, core governance settings (Numbering Format, Digits Count) become read-only to prevent accidental changes in production.",
+   "fieldname": "setup_finished",
+   "fieldtype": "Check",
+   "label": "Setup Finished",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_gov3",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-02-21 00:43:09.276049",
+ "modified_by": "Administrator",
+ "module": "Party",
+ "name": "Party Master Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Party Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/uph/party/doctype/party_master_settings/party_master_settings.py
+++ b/uph/party/doctype/party_master_settings/party_master_settings.py
@@ -34,12 +34,11 @@ class PartyMasterSettings(Document):
         enforce_strict_currency: DF.Check
         group_digits: DF.Int
         hide_balance: DF.Check
-        language: DF.Link | None
         numbering_format: DF.Literal["Concatenated", "Dash-Separated"]
         override_party_details_api: DF.Check
         party_master_fields: DF.Table[PartyMasterSettingsDocField]
         party_types: DF.Table[PartyMasterSettingsPartyType]
-        role_prefix_mode: DF.Literal["Prefix", "Suffix"]
+        role_prefix_mode: DF.Literal["Prefix for All Role", "Prefix for Secondary Role", "Suffix for All Role", "Suffix Secondary Roles"]
         role_to_bypass_duplicate_voucher: DF.Link | None
         setup_finished: DF.Check
         sync_erp_party_naming: DF.Check

--- a/uph/party/doctype/party_relationship/party_relationship.json
+++ b/uph/party/doctype/party_relationship/party_relationship.json
@@ -170,7 +170,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-07 17:27:08.273065",
+ "modified": "2026-02-21 00:44:02.377344",
  "modified_by": "Administrator",
  "module": "Party",
  "name": "Party Relationship",
@@ -209,6 +209,18 @@
    "read": 1,
    "report": 1,
    "role": "All",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Party Manager",
+   "share": 1,
    "write": 1
   }
  ],

--- a/uph/party/doctype/party_relationship_type/party_relationship_type.json
+++ b/uph/party/doctype/party_relationship_type/party_relationship_type.json
@@ -89,7 +89,7 @@
   }
  ],
  "links": [],
- "modified": "2026-02-07 17:27:46.357195",
+ "modified": "2026-02-21 00:44:16.409548",
  "modified_by": "Administrator",
  "module": "Party",
  "name": "Party Relationship Type",
@@ -127,6 +127,18 @@
    "read": 1,
    "report": 1,
    "role": "All"
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Party Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
@@ -17,6 +17,7 @@ class DataQualityDashboard {
         this.limit = 20;
         this.min_score = 70;
         this.active_tab = 'duplicates';
+        this.party_master_filter = null;
 
         // Unlinked tab state
         this.unlinked_offset = 0;
@@ -35,9 +36,28 @@ class DataQualityDashboard {
 
     init() {
         this.setup_page_actions();
+        this.setup_filters();
         this.render_layout();
         this.load_stats();
         this.load_tab_content();
+    }
+
+    setup_filters() {
+        this.party_master_field = this.page.add_field({
+            label: __('Party Master'),
+            fieldtype: 'Link',
+            fieldname: 'party_master',
+            options: 'Party Master',
+            change: () => {
+                this.party_master_filter = this.party_master_field.get_value() || null;
+                this.current_offset = 0;
+                this.unlinked_offset = 0;
+                this.unlinked_vouchers_offset = 0;
+                this.health_offset = 0;
+                this.load_stats();
+                this.load_tab_content();
+            }
+        });
     }
 
     setup_page_actions() {
@@ -67,31 +87,27 @@ class DataQualityDashboard {
     render_layout() {
         this.wrapper.html(`
             <div class="data-quality-container">
-                <!-- Stats Cards -->
+                <!-- Stats Cards - Frappe Number Card Style -->
                 <div class="stats-row" style="display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap;">
-                    <div class="stat-card" id="stat-total-parties" style="flex: 1; min-width: 120px; padding: 1rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm);">
-                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 600;">-</div>
-                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.85rem;">${__('Total Parties')}</div>
+                    <div class="stat-card" id="stat-total-parties" data-route="" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--blue-500); cursor: default;">
+                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Total Parties')}</div>
+                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 700;">-</div>
                     </div>
-                    <div class="stat-card" id="stat-duplicate-issues" style="flex: 1; min-width: 120px; padding: 1rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm);">
-                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 600; color: var(--orange-500);">-</div>
-                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.85rem;">${__('Duplicate Issues')}</div>
+                    <div class="stat-card stat-clickable" id="stat-duplicate-issues" data-issue-type="Duplicate" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--orange-500); cursor: pointer;">
+                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Duplicate Issues')}</div>
+                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 700; color: var(--orange-500);">-</div>
                     </div>
-                    <div class="stat-card" id="stat-unlinked" style="flex: 1; min-width: 120px; padding: 1rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm);">
-                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 600; color: var(--purple-500);">-</div>
-                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.85rem;">${__('Unlinked Roles')}</div>
+                    <div class="stat-card stat-clickable" id="stat-unlinked" data-issue-type="Unlinked" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--purple-500); cursor: pointer;">
+                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Unlinked Roles')}</div>
+                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 700; color: var(--purple-500);">-</div>
                     </div>
-                    <div class="stat-card" id="stat-drafts" style="flex: 1; min-width: 120px; padding: 1rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm);">
-                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 600; color: var(--yellow-500);">-</div>
-                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.85rem;">${__('Draft Vouchers')}</div>
+                    <div class="stat-card stat-clickable" id="stat-drafts" data-issue-type="Transaction Policy" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--yellow-500); cursor: pointer;">
+                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Transaction Policy')}</div>
+                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 700; color: var(--yellow-500);">-</div>
                     </div>
-                    <div class="stat-card" id="stat-unlinked-vouchers" style="flex: 1; min-width: 120px; padding: 1rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm);">
-                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 600; color: var(--red-500);">-</div>
-                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.85rem;">${__('Unlinked Vouchers')}</div>
-                    </div>
-                    <div class="stat-card" id="stat-dismissed" style="flex: 1; min-width: 120px; padding: 1rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm);">
-                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 600; color: var(--green-500);">-</div>
-                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.85rem;">${__('Ignored Issues')}</div>
+                    <div class="stat-card stat-clickable" id="stat-dismissed" data-status="Ignored" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--green-500); cursor: pointer;">
+                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Ignored Issues')}</div>
+                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 700; color: var(--green-500);">-</div>
                     </div>
                 </div>
 
@@ -137,6 +153,22 @@ class DataQualityDashboard {
             const tab = $(e.currentTarget).data('tab');
             this.switch_tab(tab);
         });
+
+        // Bind stat card clicks → navigate to Party Issue list
+        this.wrapper.find('.stat-clickable').on('click', (e) => {
+            const $card = $(e.currentTarget).closest('.stat-card');
+            const issue_type = $card.data('issue-type');
+            const status = $card.data('status');
+            let filters = {};
+            if (issue_type) {
+                filters['issue_type'] = issue_type;
+                filters['status'] = ['in', ['Open', 'Under Review']];
+            }
+            if (status) {
+                filters['status'] = status;
+            }
+            frappe.set_route('List', 'Party Issue', filters);
+        });
     }
 
     switch_tab(tab) {
@@ -161,6 +193,7 @@ class DataQualityDashboard {
     load_stats() {
         frappe.call({
             method: 'uph.party.page.data_quality_dashboard.data_quality_dashboard.get_dashboard_stats',
+            args: { party_master: this.party_master_filter || '' },
             callback: (r) => {
                 if (r.message) {
                     this.update_stats(r.message);
@@ -173,7 +206,6 @@ class DataQualityDashboard {
         $('#stat-total-parties .stat-value').text(stats.total_parties || 0);
         $('#stat-duplicate-issues .stat-value').text(stats.duplicate_issues || 0);
         $('#stat-unlinked .stat-value').text(stats.unlinked_count || 0);
-        $('#stat-unlinked-vouchers .stat-value').text(stats.unlinked_transaction_count || 0);
         $('#stat-drafts .stat-value').text(stats.draft_voucher_count || 0);
         $('#stat-dismissed .stat-value').text(stats.total_dismissed || 0);
 
@@ -187,12 +219,6 @@ class DataQualityDashboard {
             $('#tab-badge-unlinked').text(stats.unlinked_count).show();
         } else {
             $('#tab-badge-unlinked').hide();
-        }
-
-        if (stats.unlinked_transaction_count) {
-            $('#tab-badge-unlinked-vouchers').text(stats.unlinked_transaction_count).show();
-        } else {
-            $('#tab-badge-unlinked-vouchers').hide();
         }
 
         const health_total = (stats.draft_voucher_count || 0) + (stats.cancelled_unamended_count || 0);
@@ -216,7 +242,8 @@ class DataQualityDashboard {
             args: {
                 limit: this.limit,
                 offset: this.current_offset,
-                min_score: this.min_score
+                min_score: this.min_score,
+                party_master: this.party_master_filter || '',
             },
             callback: (r) => {
                 if (r.message) {
@@ -405,6 +432,7 @@ class DataQualityDashboard {
             args: {
                 limit: this.unlinked_limit,
                 offset: this.unlinked_offset,
+                party_master: this.party_master_filter || '',
             },
             callback: (r) => {
                 if (r.message) {
@@ -530,7 +558,7 @@ class DataQualityDashboard {
                             <div class="suggestion-row" style="display: flex; align-items: center; padding: 0.5rem; border: 1px solid var(--border-color); border-radius: 6px; margin-bottom: 0.5rem; cursor: pointer;" data-pm="${s.party_master}">
                                 <div style="flex: 2;">
                                     <div style="font-weight: 500;">${s.party_name}</div>
-                                    <div class="text-muted small">${s.party_master} | ${s.party_type || ''}</div>
+                                    <div class="text-muted small">${s.party_master} | ${__(s.party_type) || ''}</div>
                                 </div>
                                 <div style="flex: 1; text-align: right;">
                                     <span style="background: ${s.score >= 80 ? 'var(--green-100)' : 'var(--yellow-100)'}; color: ${s.score >= 80 ? 'var(--green-700)' : 'var(--yellow-700)'}; padding: 0.2rem 0.6rem; border-radius: 1rem; font-size: 0.8rem; font-weight: 600;">
@@ -605,10 +633,11 @@ class DataQualityDashboard {
         content.html(`<div class="text-muted">${__('Loading unlinked vouchers...')}</div>`);
 
         frappe.call({
-            method: 'uph.party.controllers.unlinked_resolver.get_unlinked_transactions',
+            method: 'uph.party.page.data_quality_dashboard.data_quality_dashboard.get_unlinked_voucher_issues',
             args: {
                 limit: this.unlinked_vouchers_limit,
                 offset: this.unlinked_vouchers_offset,
+                party_master: this.party_master_filter || '',
             },
             callback: (r) => {
                 if (r.message) {
@@ -623,7 +652,7 @@ class DataQualityDashboard {
         content.empty();
 
         if (!data.unlinked || data.unlinked.length === 0) {
-            content.html(`<div class="text-muted text-center" style="padding: 2rem;">${__('All transactions are linked to a Party Master')}</div>`);
+            content.html(`<div class="text-muted text-center" style="padding: 2rem;">${__('No unlinked voucher issues found')}</div>`);
             this.render_pagination(0, 'unlinked_vouchers');
             return;
         }
@@ -643,16 +672,16 @@ class DataQualityDashboard {
                 <div class="unlinked-row" style="display: flex; align-items: center; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border-color); background: var(--card-bg);">
                     <div style="flex: 2;">
                         <div style="font-weight: 500;">
-                            <a href="/app/${frappe.router.slug(item.role_doctype)}/${item.role_name}" target="_blank">${item.role_name}</a>
+                            <a href="/app/${frappe.router.slug(item.role_doctype)}/${item.role_name}" target="_blank">${item.display_name}</a>
                         </div>
-                        <div class="text-muted small">${__('By')} ${item.owner}</div>
+                        <div class="text-muted small">${item.owner ? __('By') + ' ' + item.owner : item.role_name}</div>
                     </div>
                     <div style="flex: 1;">
-                        <span class="indicator-pill" style="font-size: 0.8rem;">${item.role_doctype}</span>
+                        <span class="indicator-pill" style="font-size: 0.8rem;">${__(item.role_doctype)}</span>
                     </div>
-                    <div style="flex: 1;">${frappe.datetime.global_date_format(item.creation)}</div>
+                    <div style="flex: 1;">${item.creation ? frappe.datetime.global_date_format(item.creation) : '-'}</div>
                     <div style="flex: 1; text-align: right;">
-                        <button class="btn btn-default btn-xs btn-suggest" data-doctype="${item.role_doctype}" data-name="${item.role_name}" data-display="${item.role_name}">
+                        <button class="btn btn-default btn-xs btn-suggest" data-doctype="${item.role_doctype}" data-name="${item.role_name}" data-display="${item.display_name}">
                             ${__('Link')}
                         </button>
                     </div>
@@ -679,6 +708,7 @@ class DataQualityDashboard {
             args: {
                 limit: this.health_limit,
                 offset: this.health_offset,
+                party_master: this.party_master_filter || '',
             },
             callback: (r) => {
                 if (r.message) {
@@ -702,6 +732,7 @@ class DataQualityDashboard {
         content.append(`
             <div style="display: flex; padding: 0.5rem 1rem; font-weight: 600; color: var(--text-muted); font-size: 0.85rem; border-bottom: 1px solid var(--border-color);">
                 <div style="flex: 2;">${__('Party Master')}</div>
+                <div style="flex: 1;">${__('DocType')}</div>
                 <div style="flex: 1; text-align: center;">${__('Drafts')}</div>
                 <div style="flex: 1; text-align: center;">${__('Cancelled')}</div>
                 <div style="flex: 1; text-align: center;">${__('Severity')}</div>
@@ -717,7 +748,10 @@ class DataQualityDashboard {
                         <div style="font-weight: 500;">
                             <a href="/app/party-master/${p.party_master}" target="_blank">${p.party_name}</a>
                         </div>
-                        <div class="text-muted small">${p.party_number || '-'} | ${p.party_type || ''}</div>
+                        <div class="text-muted small">${p.party_number || '-'} | ${__(p.party_type) || ''}</div>
+                    </div>
+                    <div style="flex: 1;">
+                        <span class="indicator-pill" style="font-size: 0.75rem;">${__(p.reference_doctype) || '-'}</span>
                     </div>
                     <div style="flex: 1; text-align: center;">
                         <span style="font-weight: 600; color: ${p.draft_count > 0 ? 'var(--yellow-600)' : 'var(--text-muted)'};">${p.draft_count}</span>
@@ -726,7 +760,7 @@ class DataQualityDashboard {
                         <span style="font-weight: 600; color: ${p.cancelled_unamended_count > 0 ? 'var(--red-500)' : 'var(--text-muted)'};">${p.cancelled_unamended_count}</span>
                     </div>
                     <div style="flex: 1; text-align: center;">
-                        <span style="color: ${severity_color}; font-weight: 600; font-size: 0.85rem;">${p.severity}</span>
+                        <span style="color: ${severity_color}; font-weight: 600; font-size: 0.85rem;">${__(p.severity)}</span>
                     </div>
                     <div style="flex: 1; text-align: right;">
                         <button class="btn btn-default btn-xs btn-detail" data-pm="${p.party_master}">

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
@@ -58,6 +58,23 @@ class DataQualityDashboard {
                 this.load_tab_content();
             }
         });
+
+        this.doctype_filter_field = this.page.add_field({
+            label: __('DocType'),
+            fieldtype: 'Link',
+            fieldname: 'reference_doctype',
+            options: 'DocType',
+            get_query: () => ({ filters: { istitle: 0, issingle: 0 } }),
+            change: () => {
+                this.doctype_filter = this.doctype_filter_field.get_value() || null;
+                this.unlinked_vouchers_offset = 0;
+                this.health_offset = 0;
+                this.load_tab_content();
+            }
+        });
+
+        // Hide initially since default tab is Duplicates
+        $(this.doctype_filter_field.wrapper).closest('.frappe-control').hide();
     }
 
     setup_page_actions() {
@@ -175,6 +192,15 @@ class DataQualityDashboard {
         this.active_tab = tab;
         this.wrapper.find('.nav-link').removeClass('active');
         this.wrapper.find(`.nav-link[data-tab="${tab}"]`).addClass('active');
+
+        // Show/hide DocType filter based on tab
+        const dt_wrapper = $(this.doctype_filter_field.wrapper).closest('.frappe-control');
+        if (tab === 'unlinked_vouchers' || tab === 'health') {
+            dt_wrapper.show();
+        } else {
+            dt_wrapper.hide();
+        }
+
         this.load_tab_content();
     }
 
@@ -638,6 +664,7 @@ class DataQualityDashboard {
                 limit: this.unlinked_vouchers_limit,
                 offset: this.unlinked_vouchers_offset,
                 party_master: this.party_master_filter || '',
+                reference_doctype: this.doctype_filter || '',
             },
             callback: (r) => {
                 if (r.message) {
@@ -690,13 +717,90 @@ class DataQualityDashboard {
 
             row.find('.btn-suggest').on('click', (e) => {
                 const $btn = $(e.currentTarget);
-                this.show_link_dialog($btn.data('doctype'), $btn.data('name'), $btn.data('display'));
+                this.show_voucher_link_dialog($btn.data('doctype'), $btn.data('name'), $btn.data('display'), $btn.data('role'));
             });
 
             content.append(row);
         });
 
         this.render_pagination(data.total, 'unlinked_vouchers');
+    }
+
+    show_voucher_link_dialog(voucher_doctype, voucher_name, voucher_display, role_name) {
+        // Find the mapped role doctype (e.g. Sales Invoice -> Customer)
+        frappe.db.get_value('Party Master Settings', null, 'document_types')
+            .then(() => {
+                // To keep it simple, we ask the server for the role doctype/name of this voucher
+                frappe.call({
+                    method: 'frappe.client.get',
+                    args: { doctype: voucher_doctype, name: voucher_name },
+                    callback: (r) => {
+                        if (r.message) {
+                            const doc = r.message;
+                            let role_doctype = '';
+                            let actual_role_name = '';
+
+                            // Guess the role field based on common patterns
+                            if (doc.customer) { role_doctype = 'Customer'; actual_role_name = doc.customer; }
+                            else if (doc.supplier) { role_doctype = 'Supplier'; actual_role_name = doc.supplier; }
+                            else if (doc.employee) { role_doctype = 'Employee'; actual_role_name = doc.employee; }
+                            else if (doc.party_type && doc.party) { role_doctype = doc.party_type; actual_role_name = doc.party; }
+
+                            if (!role_doctype || !actual_role_name) {
+                                frappe.msgprint(__('Could not determine the underlying party role (Customer/Supplier) for {0}', [voucher_display]));
+                                return;
+                            }
+
+                            this._render_voucher_link_dialog(voucher_doctype, voucher_name, voucher_display, role_doctype, actual_role_name);
+                        }
+                    }
+                });
+            });
+    }
+
+    _render_voucher_link_dialog(voucher_doctype, voucher_name, voucher_display, role_doctype, role_name) {
+        const d = new frappe.ui.Dialog({
+            title: __('Link {0} to Party Master', [voucher_display]),
+            fields: [
+                {
+                    fieldname: 'info',
+                    fieldtype: 'HTML',
+                    options: `
+                        <div class="alert alert-info">
+                            ${__('This voucher relies on the <b>{0}</b> record: <b>{1}</b>. By linking this {0} to a Party Master, this voucher (and all others using it) will be resolved.', [role_doctype, role_name])}
+                        </div>
+                    `
+                },
+                {
+                    fieldname: 'party_master',
+                    fieldtype: 'Link',
+                    label: __('Party Master'),
+                    options: 'Party Master',
+                    get_query: () => ({ filters: { is_group: 0, disabled: 0 } }),
+                    reqd: 1
+                }
+            ],
+            primary_action_label: __('Link to Party Master'),
+            primary_action: (values) => {
+                frappe.call({
+                    method: 'uph.party.controllers.unlinked_resolver.resolve_unlinked_voucher',
+                    args: {
+                        role_doctype: role_doctype,
+                        role_name: role_name,
+                        party_master: values.party_master,
+                    },
+                    callback: (r) => {
+                        if (r.message && r.message.success) {
+                            d.hide();
+                            frappe.show_alert({ message: r.message.message, indicator: 'green' });
+                            this.load_stats();
+                            this.load_unlinked_vouchers();
+                        }
+                    }
+                });
+            }
+        });
+        d.show();
     }
 
     load_health() {
@@ -709,6 +813,7 @@ class DataQualityDashboard {
                 limit: this.health_limit,
                 offset: this.health_offset,
                 party_master: this.party_master_filter || '',
+                reference_doctype: this.doctype_filter || '',
             },
             callback: (r) => {
                 if (r.message) {
@@ -781,35 +886,126 @@ class DataQualityDashboard {
     }
 
     show_health_detail(party_master) {
+        const d = new frappe.ui.Dialog({
+            title: __('Transaction Policy Issues: {0}', [party_master]),
+            size: 'large',
+            fields: [
+                {
+                    fieldname: 'issues_html',
+                    fieldtype: 'HTML'
+                }
+            ],
+            primary_action_label: __('Close'),
+            primary_action: () => d.hide()
+        });
+
+        d.fields_dict.issues_html.$wrapper.html(`<div class="text-muted text-center" style="padding: 2rem;">${__('Loading issues...')}</div>`);
+        d.show();
+
         frappe.call({
             method: 'uph.party.controllers.transaction_health.get_party_health_detail',
             args: { party_master },
             callback: (r) => {
                 if (!r.message || !r.message.vouchers || !r.message.vouchers.length) {
-                    frappe.msgprint(__('No problematic vouchers found for {0}', [party_master]));
+                    d.fields_dict.issues_html.$wrapper.html(
+                        `<div class="text-muted text-center" style="padding: 2rem;">${__('No problematic vouchers found for {0}', [party_master])}</div>`
+                    );
                     return;
                 }
 
-                let html = '<div class="frappe-list">';
+                let html = `
+                    <div style="display: flex; padding: 0.5rem 1rem; font-weight: 600; color: var(--text-muted); font-size: 0.85rem; border-bottom: 1px solid var(--border-color);">
+                        <div style="flex: 2;">${__('Document')}</div>
+                        <div style="flex: 1;">${__('Issue')}</div>
+                        <div style="flex: 1;">${__('Date')}</div>
+                        <div style="flex: 1.5; text-align: right;">${__('Actions')}</div>
+                    </div>
+                `;
+
                 r.message.vouchers.forEach(v => {
-                    const issue_color = v.issue_type === 'Draft' ? 'orange' : 'red';
+                    let issue_color = 'gray';
+                    if (v.issue_code === 'draft_overdue') issue_color = 'orange';
+                    if (v.issue_code === 'cancelled_referenced') issue_color = 'red';
+                    if (v.issue_code === 'party_master_mismatch') issue_color = 'blue';
+
+                    let actions_html = '';
+
+                    // Action logic based on docstatus and issue code
+                    if (v.docstatus === 0 && v.issue_code === 'draft_overdue') {
+                        actions_html += `
+                            <button class="btn btn-primary btn-xs btn-action" data-action="submit" data-issue="${v.issue_name}" title="${__('Submit Document')}">
+                                <i class="fa fa-check"></i> ${__('Submit')}
+                            </button>
+                            <button class="btn btn-default btn-xs btn-action" data-action="cancel" data-issue="${v.issue_name}" title="${__('Cancel Document')}">
+                                <i class="fa fa-ban"></i>
+                            </button>
+                        `;
+                    } else if (v.docstatus === 1 && v.issue_code === 'cancelled_referenced') {
+                        actions_html += `
+                            <button class="btn btn-danger btn-xs btn-action" data-action="cancel" data-issue="${v.issue_name}" title="${__('Cancel Document')}">
+                                <i class="fa fa-ban"></i> ${__('Cancel')}
+                            </button>
+                        `;
+                    }
+
+                    // Always allow explicit dismiss from the dashboard
+                    actions_html += `
+                        <button class="btn btn-default btn-xs btn-action" data-action="dismiss" data-issue="${v.issue_name}" title="${__('Ignore Issue')}" style="margin-left: 4px;">
+                            <i class="fa fa-times"></i>
+                        </button>
+                    `;
+
                     html += `
-                        <div style="padding: 0.5rem; border-bottom: 1px solid var(--border-color); display: flex; justify-content: space-between;">
-                            <div>
-                                <a href="/app/${frappe.router.slug(v.doctype)}/${v.name}" target="_blank">${v.doctype}: ${v.name}</a>
+                        <div class="health-issue-row" style="display: flex; align-items: center; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border-color);">
+                            <div style="flex: 2;">
+                                <div style="font-weight: 500;">
+                                    <a href="/app/${frappe.router.slug(v.doctype)}/${v.name}" target="_blank">${v.doctype}: ${v.name}</a>
+                                </div>
+                                <div class="text-muted small">${v.docstatus === 0 ? 'Draft' : (v.docstatus === 1 ? 'Submitted' : 'Cancelled')}</div>
                             </div>
-                            <div>
+                            <div style="flex: 1;">
                                 <span class="indicator-pill ${issue_color}">${v.issue_type}</span>
+                            </div>
+                            <div style="flex: 1; font-size: 0.85rem;" class="text-muted">
+                                ${v.creation ? frappe.datetime.global_date_format(v.creation) : '-'}
+                            </div>
+                            <div style="flex: 1.5; text-align: right;">
+                                ${actions_html}
                             </div>
                         </div>
                     `;
                 });
-                html += '</div>';
 
-                frappe.msgprint({
-                    title: __('Voucher Issues — {0}', [party_master]),
-                    message: html,
-                    wide: true,
+                d.fields_dict.issues_html.$wrapper.html(html);
+
+                // Bind actions
+                d.fields_dict.issues_html.$wrapper.find('.btn-action').on('click', (e) => {
+                    const $btn = $(e.currentTarget);
+                    const action = $btn.data('action');
+                    const issue = $btn.data('issue');
+
+                    let confirm_msg = '';
+                    if (action === 'submit') confirm_msg = __('Are you sure you want to permanently Submit this document?');
+                    if (action === 'cancel') confirm_msg = __('Are you sure you want to permanently Cancel this document?');
+                    if (action === 'dismiss') confirm_msg = __('Ignore this issue? It won\'t show up again until re-scanned.');
+
+                    frappe.confirm(confirm_msg, () => {
+                        $btn.prop('disabled', true);
+                        frappe.call({
+                            method: 'uph.party.controllers.transaction_health.resolve_health_issue',
+                            args: { issue_name: issue, action: action },
+                            callback: (res) => {
+                                if (res.message && res.message.success) {
+                                    $btn.closest('.health-issue-row').fadeOut(300, function () { $(this).remove(); });
+                                    frappe.show_alert({ message: res.message.message, indicator: 'green' });
+                                    this.load_stats();
+                                    this.load_health();
+                                } else {
+                                    $btn.prop('disabled', false);
+                                }
+                            }
+                        });
+                    });
                 });
             }
         });

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
@@ -14,67 +14,93 @@ class DataQualityDashboard {
         this.page = page;
         this.wrapper = $(page.main);
         this.current_offset = 0;
-        this.limit = 20;
+        this.limit = 50;
         this.min_score = 70;
         this.active_tab = 'duplicates';
         this.party_master_filter = null;
 
         // Unlinked tab state
         this.unlinked_offset = 0;
-        this.unlinked_limit = 20;
+        this.unlinked_limit = 50;
 
         // Health tab state
         this.health_offset = 0;
-        this.health_limit = 20;
+        this.health_limit = 50;
 
         // Unlinked Vouchers tab state
         this.unlinked_vouchers_offset = 0;
-        this.unlinked_vouchers_limit = 20;
+        this.unlinked_vouchers_limit = 50;
 
         this.init();
     }
 
     init() {
         this.setup_page_actions();
-        this.setup_filters();
         this.render_layout();
+        this.setup_filters();
         this.load_stats();
         this.load_tab_content();
     }
 
     setup_filters() {
-        this.party_master_field = this.page.add_field({
-            label: __('Party Master'),
-            fieldtype: 'Link',
-            fieldname: 'party_master',
-            options: 'Party Master',
-            change: () => {
-                this.party_master_filter = this.party_master_field.get_value() || null;
-                this.current_offset = 0;
-                this.unlinked_offset = 0;
-                this.unlinked_vouchers_offset = 0;
-                this.health_offset = 0;
-                this.load_stats();
-                this.load_tab_content();
-            }
+        const filter_row = this.wrapper.find('.dashboard-filters');
+
+        // Clear containers
+        const pm_container = filter_row.find('.pm-filter-container').empty();
+        const dt_container = filter_row.find('.dt-filter-container').empty();
+
+        this.party_master_field = frappe.ui.form.make_control({
+            df: {
+                label: '',
+                fieldtype: 'Link',
+                fieldname: 'party_master',
+                options: 'Party Master',
+                placeholder: __('Filter by Party Master'),
+                get_query: () => ({ filters: { is_group: 0, disabled: 0 } }),
+                change: () => {
+                    this.party_master_filter = this.party_master_field.get_value() || null;
+                    this.current_offset = 0;
+                    this.unlinked_offset = 0;
+                    this.unlinked_vouchers_offset = 0;
+                    this.health_offset = 0;
+                    this.load_stats();
+                    this.load_tab_content();
+                }
+            },
+            parent: pm_container,
+            render_input: true
         });
 
-        this.doctype_filter_field = this.page.add_field({
-            label: __('DocType'),
-            fieldtype: 'Link',
-            fieldname: 'reference_doctype',
-            options: 'DocType',
-            get_query: () => ({ filters: { istitle: 0, issingle: 0 } }),
-            change: () => {
-                this.doctype_filter = this.doctype_filter_field.get_value() || null;
-                this.unlinked_vouchers_offset = 0;
-                this.health_offset = 0;
-                this.load_tab_content();
-            }
+        this.doctype_filter_field = frappe.ui.form.make_control({
+            df: {
+                label: '',
+                fieldtype: 'Link',
+                fieldname: 'reference_doctype',
+                options: 'DocType',
+                placeholder: __('Filter by DocType'),
+                get_query: () => {
+                    const tx_doctypes = (frappe.boot.party_master_on_doctypes_depend_field || [])
+                        .map(d => d[0]) // parent_doctype is at index 0
+                        .filter((v, i, a) => a.indexOf(v) === i); // unique
+
+                    if (tx_doctypes.length) {
+                        return { filters: { name: ['in', tx_doctypes] } };
+                    }
+                    return { filters: { istable: 0, issingle: 0 } };
+                },
+                change: () => {
+                    this.doctype_filter = this.doctype_filter_field.get_value() || null;
+                    this.unlinked_vouchers_offset = 0;
+                    this.health_offset = 0;
+                    this.load_tab_content();
+                }
+            },
+            parent: dt_container,
+            render_input: true
         });
 
         // Hide initially since default tab is Duplicates
-        $(this.doctype_filter_field.wrapper).closest('.frappe-control').hide();
+        dt_container.parent().hide();
     }
 
     setup_page_actions() {
@@ -103,7 +129,7 @@ class DataQualityDashboard {
 
     render_layout() {
         this.wrapper.html(`
-            <div class="data-quality-container">
+            <div class="data-quality-container" style="padding: 1rem;">
                 <!-- Stats Cards - Frappe Number Card Style -->
                 <div class="stats-row" style="display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap;">
                     <div class="stat-card" id="stat-total-parties" data-route="" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--blue-500); cursor: default;">
@@ -118,17 +144,24 @@ class DataQualityDashboard {
                         <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Unlinked Roles')}</div>
                         <div class="stat-value" style="font-size: 1.75rem; font-weight: 700; color: var(--purple-500);">-</div>
                     </div>
-                    <div class="stat-card stat-clickable" id="stat-drafts" data-issue-type="Transaction Policy" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--yellow-500); cursor: pointer;">
-                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Transaction Policy')}</div>
-                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 700; color: var(--yellow-500);">-</div>
-                    </div>
-                    <div class="stat-card stat-clickable" id="stat-dismissed" data-status="Ignored" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--green-500); cursor: pointer;">
-                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Ignored Issues')}</div>
-                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 700; color: var(--green-500);">-</div>
+                    <div class="stat-card stat-clickable" id="stat-policy-issues" data-issue-type="Transaction Policy" style="flex: 1; min-width: 140px; padding: 1rem 1rem 1rem 1.25rem; background: var(--card-bg); border-radius: 8px; box-shadow: var(--shadow-sm); border-left: 4px solid var(--red-500); cursor: pointer;">
+                        <div class="stat-label" style="color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem;">${__('Transaction Health')}</div>
+                        <div class="stat-value" style="font-size: 1.75rem; font-weight: 700; color: var(--red-500);">-</div>
                     </div>
                 </div>
 
-                <!-- Tabs -->
+                <!-- Filters Row (Moved below stats) -->
+                <div class="dashboard-filters" style="display: flex; gap: 1rem; margin-bottom: 1.5rem; align-items: center; background: var(--card-bg); padding: 0.75rem 1rem; border-radius: 8px; box-shadow: var(--shadow-sm); border: 1px solid var(--border-color);">
+                    <div style="flex: 1; min-width: 200px;">
+                        <div class="pm-filter-container"></div>
+                    </div>
+                    <div style="flex: 1; min-width: 200px;">
+                        <div class="dt-filter-container"></div>
+                    </div>
+                    <div style="flex: 2;"></div>
+                </div>
+
+                <!-- Tab Links -->
                 <ul class="nav nav-tabs" role="tablist" style="margin-bottom: 1rem;">
                     <li class="nav-item">
                         <a class="nav-link active" data-tab="duplicates" href="#" role="tab">
@@ -194,11 +227,11 @@ class DataQualityDashboard {
         this.wrapper.find(`.nav-link[data-tab="${tab}"]`).addClass('active');
 
         // Show/hide DocType filter based on tab
-        const dt_wrapper = $(this.doctype_filter_field.wrapper).closest('.frappe-control');
+        const dt_container = this.wrapper.find('.dt-filter-container').parent();
         if (tab === 'unlinked_vouchers' || tab === 'health') {
-            dt_wrapper.show();
+            dt_container.show();
         } else {
-            dt_wrapper.hide();
+            dt_container.hide();
         }
 
         this.load_tab_content();
@@ -868,7 +901,7 @@ class DataQualityDashboard {
                         <span style="color: ${severity_color}; font-weight: 600; font-size: 0.85rem;">${__(p.severity)}</span>
                     </div>
                     <div style="flex: 1; text-align: right;">
-                        <button class="btn btn-default btn-xs btn-detail" data-pm="${p.party_master}">
+                        <button class="btn btn-default btn-xs btn-detail" data-pm="${p.party_master}" data-dt="${p.reference_doctype}">
                             ${__('View Details')}
                         </button>
                     </div>
@@ -876,7 +909,8 @@ class DataQualityDashboard {
             `);
 
             row.find('.btn-detail').on('click', (e) => {
-                this.show_health_detail($(e.currentTarget).data('pm'));
+                const $btn = $(e.currentTarget);
+                this.show_health_detail($btn.data('pm'), $btn.data('dt'));
             });
 
             content.append(row);
@@ -885,9 +919,14 @@ class DataQualityDashboard {
         this.render_pagination(data.total, 'health');
     }
 
-    show_health_detail(party_master) {
+    show_health_detail(party_master, reference_doctype = null) {
+        let title = __('Transaction Policy Issues: {0}', [party_master]);
+        if (reference_doctype) {
+            title = __('Transaction Policy Issues: {0} ({1})', [party_master, reference_doctype]);
+        }
+
         const d = new frappe.ui.Dialog({
-            title: __('Transaction Policy Issues: {0}', [party_master]),
+            title: title,
             size: 'large',
             fields: [
                 {
@@ -904,7 +943,7 @@ class DataQualityDashboard {
 
         frappe.call({
             method: 'uph.party.controllers.transaction_health.get_party_health_detail',
-            args: { party_master },
+            args: { party_master, reference_doctype },
             callback: (r) => {
                 if (!r.message || !r.message.vouchers || !r.message.vouchers.length) {
                     d.fields_dict.issues_html.$wrapper.html(

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.json
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.json
@@ -16,6 +16,9 @@
         },
         {
             "role": "Accounts Manager"
+        },
+        {
+            "role": "Party Manager"
         }
     ],
     "standard": "Yes",

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.py
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.py
@@ -8,7 +8,9 @@ import json
 
 
 @frappe.whitelist()
-def get_duplicate_issues(limit: int = 50, offset: int = 0, min_score: float = 0):
+def get_duplicate_issues(
+    limit: int = 50, offset: int = 0, min_score: float = 0, party_master: str = None
+):
     """
     Get duplicate Party Issues from the governance registry.
     """
@@ -21,6 +23,8 @@ def get_duplicate_issues(limit: int = 50, offset: int = 0, min_score: float = 0)
     filters = {"issue_type": "Duplicate", "status": ["in", ["Open", "Under Review"]]}
     if float(min_score) > 0:
         filters["score"] = [">=", float(min_score)]
+    if party_master:
+        filters["party"] = party_master
 
     duplicates = frappe.get_all(
         "Party Issue",
@@ -63,63 +67,146 @@ def get_duplicate_issues(limit: int = 50, offset: int = 0, min_score: float = 0)
 
 
 @frappe.whitelist()
-def get_dashboard_stats():
+def get_dashboard_stats(party_master: str = None):
     """
-    Get summary statistics. Delegates to canonical modules for health and unlinked
-    counts to avoid duplicating logic from transaction_health.py and unlinked_resolver.py.
+    Get summary statistics sourced entirely from the Party Issue doctype.
+    Uses a single aggregation query for all issue counts.
+    Optionally filters by party_master.
     """
+    party_filter = ""
+    params = {}
+    if party_master:
+        party_filter = "WHERE party = %(party_master)s"
+        params["party_master"] = party_master
 
-    def _cached_int(key, fallback):
-        val = frappe.cache.get_value(key)
-        if val is None:
-            return fallback
-        try:
-            return int(val)
-        except Exception:
-            return fallback
+    # Single aggregation query on Party Issue
+    issue_counts = frappe.db.sql(
+        f"""
+        SELECT issue_type, status, COUNT(*) as cnt
+        FROM `tabParty Issue`
+        {party_filter}
+        GROUP BY issue_type, status
+        """,
+        params,
+        as_dict=True,
+    )
+
+    # Build a lookup: (issue_type, status) -> count
+    count_map = {}
+    for row in issue_counts:
+        count_map[(row.issue_type, row.status)] = row.cnt
+
+    def _open_count(issue_type):
+        return count_map.get((issue_type, "Open"), 0) + count_map.get(
+            (issue_type, "Under Review"), 0
+        )
+
+    # All ignored/resolved counts (across all issue types)
+    total_ignored = sum(v for (k, s), v in count_map.items() if s == "Ignored")
 
     stats = {
-        "total_parties": _cached_int(
-            "uph:stats:total_parties",
-            frappe.db.count("Party Master", {"is_group": 0}),
-        ),
-        "total_groups": _cached_int(
-            "uph:stats:total_groups",
-            frappe.db.count("Party Master", {"is_group": 1}),
-        ),
-        "duplicate_issues": _cached_int(
-            "uph:stats:duplicate_open",
-            frappe.db.count(
-                "Party Issue",
-                {"issue_type": "Duplicate", "status": ["in", ["Open", "Under Review"]]},
-            ),
-        ),
-        "total_dismissed": _cached_int(
-            "uph:stats:duplicate_ignored",
-            frappe.db.count(
-                "Party Issue", {"issue_type": "Duplicate", "status": "Ignored"}
-            ),
-        ),
-        "total_merged": _cached_int(
-            "uph:stats:duplicate_resolved",
-            frappe.db.count(
-                "Party Issue", {"issue_type": "Duplicate", "status": "Resolved"}
-            ),
-        ),
-        "unlinked_count": _cached_int(
-            "uph:stats:unlinked_open",
-            frappe.db.count(
-                "Party Issue",
-                {"issue_type": "Unlinked", "status": ["in", ["Open", "Under Review"]]},
-            ),
-        ),
-        "draft_voucher_count": _cached_int("uph:stats:policy_draft", 0),
-        "cancelled_unamended_count": _cached_int("uph:stats:policy_cancelled", 0),
-        "unlinked_transaction_count": _cached_int("uph:stats:policy_mismatch", 0),
-        "incomplete_parties": _cached_int("uph:stats:incomplete_count", 0),
-        "last_updated": frappe.cache.get_value("uph:stats:last_updated"),
+        "total_parties": frappe.db.count("Party Master", {"is_group": 0}),
+        "total_groups": frappe.db.count("Party Master", {"is_group": 1}),
+        # Duplicates
+        "duplicate_issues": _open_count("Duplicate"),
+        "total_dismissed": total_ignored,
+        "total_merged": count_map.get(("Duplicate", "Resolved"), 0),
+        # Unlinked roles
+        "unlinked_count": _open_count("Unlinked"),
+        # Transaction policy / health
+        "draft_voucher_count": _open_count("Transaction Policy"),
+        "cancelled_unamended_count": count_map.get(("Health", "Open"), 0)
+        + count_map.get(("Health", "Under Review"), 0),
+        "unlinked_transaction_count": _open_count("Unlinked"),
+        "incomplete_parties": count_map.get(("Health", "Open"), 0),
+        "last_updated": frappe.utils.now_datetime(),
     }
     return stats
+
+
+@frappe.whitelist()
+def get_unlinked_voucher_issues(
+    limit: int = 20, offset: int = 0, party_master: str = None
+):
+    """
+    Get unlinked vouchers by querying transaction tables directly.
+    Finds vouchers where party_master is NULL or empty.
+    Optionally filters by a specific party_master (for linked party checks).
+    """
+    limit = cint(limit) or 20
+    offset = cint(offset) or 0
+
+    from uph.party.controllers.transaction_health import _get_transaction_doctypes
+
+    tx_doctypes = _get_transaction_doctypes()
+    if not tx_doctypes:
+        return {"unlinked": [], "total": 0}
+
+    total = 0
+    selects = []
+
+    for dt_info in tx_doctypes:
+        dt = dt_info.get("document_type")
+        parent_dt = dt_info.get("parent_doctype") or dt
+        if not dt or not frappe.db.exists("DocType", dt):
+            continue
+
+        meta = frappe.get_meta(dt)
+        if not meta.has_field("party_master"):
+            continue
+
+        # Build the WHERE clause
+        where_clause = "(party_master IS NULL OR party_master = '')"
+
+        # Count
+        total += frappe.db.count(dt, {"party_master": ["is", "not set"]})
+
+        is_child = meta.istable
+
+        if is_child:
+            selects.append(
+                f"""
+                SELECT
+                    `parenttype` AS role_doctype,
+                    `parent` AS role_name,
+                    CONCAT(`parenttype`, ': ', `parent`) AS display_name,
+                    '' AS owner,
+                    `creation` AS creation
+                FROM `tab{dt}`
+                WHERE {where_clause}
+            """
+            )
+        else:
+            owner_expr = "''"
+            if meta.has_field("owner"):
+                owner_expr = "COALESCE(`owner`, '')"
+
+            selects.append(
+                f"""
+                SELECT
+                    {frappe.db.escape(dt)} AS role_doctype,
+                    `name` AS role_name,
+                    CONCAT({frappe.db.escape(dt)}, ': ', `name`) AS display_name,
+                    {owner_expr} AS owner,
+                    `creation` AS creation
+                FROM `tab{dt}`
+                WHERE {where_clause}
+            """
+            )
+
+    if not selects:
+        return {"unlinked": [], "total": 0}
+
+    union_query = " UNION ALL ".join(selects)
+    final_query = f"""
+        SELECT * FROM ({union_query}) AS combined
+        ORDER BY creation DESC
+        LIMIT {limit} OFFSET {offset}
+    """
+
+    rows = frappe.db.sql(final_query, as_dict=True)
+
+    return {"unlinked": rows, "total": total}
 
 
 @frappe.whitelist()

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.py
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.py
@@ -126,12 +126,16 @@ def get_dashboard_stats(party_master: str = None):
 
 @frappe.whitelist()
 def get_unlinked_voucher_issues(
-    limit: int = 20, offset: int = 0, party_master: str = None
+    limit: int = 20,
+    offset: int = 0,
+    party_master: str = None,
+    reference_doctype: str = None,
 ):
     """
     Get unlinked vouchers by querying transaction tables directly.
     Finds vouchers where party_master is NULL or empty.
     Optionally filters by a specific party_master (for linked party checks).
+    Optionally filters by specific reference_doctype.
     """
     limit = cint(limit) or 20
     offset = cint(offset) or 0
@@ -149,6 +153,14 @@ def get_unlinked_voucher_issues(
         dt = dt_info.get("document_type")
         parent_dt = dt_info.get("parent_doctype") or dt
         if not dt or not frappe.db.exists("DocType", dt):
+            continue
+
+        # Apply doctype filter
+        if (
+            reference_doctype
+            and dt != reference_doctype
+            and parent_dt != reference_doctype
+        ):
             continue
 
         meta = frappe.get_meta(dt)

--- a/uph/party/page/uph_setup_wizard/uph_setup_wizard.json
+++ b/uph/party/page/uph_setup_wizard/uph_setup_wizard.json
@@ -14,6 +14,9 @@
     "roles": [
         {
             "role": "System Manager"
+        },
+        {
+            "role": "Party Manager"
         }
     ],
     "script": "",

--- a/uph/party/report/chronological_party_ledger/chronological_party_ledger.json
+++ b/uph/party/report/chronological_party_ledger/chronological_party_ledger.json
@@ -29,6 +29,9 @@
   },
   {
    "role": "Auditor"
+  },
+  {
+   "role": "Party Manager"
   }
  ],
  "timeout": 0

--- a/uph/party/report/party_account_balances/party_account_balances.json
+++ b/uph/party/report/party_account_balances/party_account_balances.json
@@ -20,6 +20,10 @@
  "ref_doctype": "GL Entry",
  "report_name": "Party Account Balances",
  "report_type": "Script Report",
- "roles": [],
+ "roles": [
+  {
+   "role": "Party Manager"
+  }
+ ],
  "timeout": 0
 }

--- a/uph/party/report/party_account_statement/party_account_statement.json
+++ b/uph/party/report/party_account_statement/party_account_statement.json
@@ -20,6 +20,10 @@
  "ref_doctype": "GL Entry",
  "report_name": "Party Account Statement",
  "report_type": "Script Report",
- "roles": [],
+ "roles": [
+  {
+   "role": "Party Manager"
+  }
+ ],
  "timeout": 0
 }

--- a/uph/party/report/party_accounting_ledger/party_accounting_ledger.json
+++ b/uph/party/report/party_accounting_ledger/party_accounting_ledger.json
@@ -20,6 +20,10 @@
  "ref_doctype": "GL Entry",
  "report_name": "Party Accounting Ledger",
  "report_type": "Script Report",
- "roles": [],
+ "roles": [
+  {
+   "role": "Party Manager"
+  }
+ ],
  "timeout": 0
 }

--- a/uph/party/report/party_health/party_health.json
+++ b/uph/party/report/party_health/party_health.json
@@ -1,29 +1,32 @@
 {
-    "add_total_row": 0,
-    "columns": [],
-    "creation": "2026-02-14 17:15:00.000000",
-    "disabled": 0,
-    "docstatus": 0,
-    "doctype": "Report",
-    "filters": [],
-    "idx": 0,
-    "is_standard": "Yes",
-    "letter_head": "Standard",
-    "modified": "2026-02-14 17:15:00.000000",
-    "modified_by": "Administrator",
-    "module": "Party",
-    "name": "Party Health",
-    "owner": "Administrator",
-    "prepared_report": 0,
-    "ref_doctype": "Party Master",
-    "report_name": "Party Health",
-    "report_type": "Script Report",
-    "roles": [
-        {
-            "role": "System Manager"
-        },
-        {
-            "role": "Accounting Manager"
-        }
-    ]
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2026-02-14 17:15:00.000000",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "Standard",
+ "modified": "2026-02-14 17:15:00.000000",
+ "modified_by": "Administrator",
+ "module": "Party",
+ "name": "Party Health",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Party Master",
+ "report_name": "Party Health",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Accounting Manager"
+  },
+  {
+   "role": "Party Manager"
+  }
+ ]
 }

--- a/uph/party/report/party_master_health_report/party_master_health_report.json
+++ b/uph/party/report/party_master_health_report/party_master_health_report.json
@@ -26,6 +26,9 @@
   },
   {
    "role": "Administrator"
+  },
+  {
+   "role": "Party Manager"
   }
  ],
  "timeout": 0

--- a/uph/party/report/party_master_ledger/party_master_ledger.json
+++ b/uph/party/report/party_master_ledger/party_master_ledger.json
@@ -28,6 +28,9 @@
   },
   {
    "role": "\u0645\u062f\u062e\u0644 \u062f\u0641\u0627\u062a\u0631 \u064a\u0648\u0645\u064a\u0629"
+  },
+  {
+   "role": "Party Manager"
   }
  ],
  "timeout": 0

--- a/uph/party/workspace/party/party.json
+++ b/uph/party/workspace/party/party.json
@@ -195,7 +195,17 @@
     "parent_page": "",
     "public": 1,
     "quick_lists": [],
-    "roles": [],
+    "roles": [
+        {
+            "role": "Party Manager"
+        },
+        {
+            "role": "System Manager"
+        },
+        {
+            "role": "Accounts Manager"
+        }
+    ],
     "sequence_id": 9.0,
     "shortcuts": [
         {

--- a/uph/patches.txt
+++ b/uph/patches.txt
@@ -8,3 +8,4 @@ uph.patches.add_indexes
 uph.patches.setup_pm_fields
 uph.patches.populate_normalized_party_name
 uph.patches.migrate_duplicate_exclusion_to_party_issue
+uph.patches.rescan_transaction_health_and_unlinked

--- a/uph/patches/rescan_transaction_health_and_unlinked.py
+++ b/uph/patches/rescan_transaction_health_and_unlinked.py
@@ -8,21 +8,24 @@ entries so the new dashboard shows correct data.
 
 Steps
 -----
-1. Run ``run_transaction_policy_scan()`` – creates Party Issue entries
-   for draft-overdue, cancelled-referenced, and party-master-mismatch
-   vouchers that have not yet been registered.
-2. Run ``run_unlinked_issue_scan()`` – creates Party Issue entries for
-   role records (Customer, Supplier, Employee, …) that are not linked
-   to a Party Master.
-3. Auto-resolve false-positive Unlinked issues where the referenced
+1. Auto-resolve false-positive Unlinked issues where the referenced
    record already has a ``party_master`` set (i.e. was linked after
    the issue was created).
+2. Auto-resolve false-positive Transaction Policy issues where the referenced
+   voucher is no longer in the relevant state (e.g. draft was submitted).
+3. Run ``run_transaction_policy_scan()`` – creates Party Issue entries
+   for draft-overdue, cancelled-referenced, and party-master-mismatch
+   vouchers that have not yet been registered.
+4. Run ``run_unlinked_issue_scan()`` – creates Party Issue entries for
+   role records (Customer, Supplier, Employee, …) that are not linked
+   to a Party Master.
 
 Both scanners are idempotent (they call ``create_party_issue_if_missing``),
 so running them on a site that already has partial data is safe.
 """
 
 import frappe
+import json
 from frappe.utils import now_datetime
 
 
@@ -32,44 +35,35 @@ def execute():
 
     frappe.flags.in_patch = True
 
-    # 1. Transaction policy scan
-    try:
-        from uph.party.controllers.transaction_health import (
-            run_transaction_policy_scan,
-        )
-
-        run_transaction_policy_scan()
-        frappe.db.commit()
-    except Exception as e:
-        frappe.log_error(
-            title="Patch: transaction policy scan failed",
-            message=str(e),
-        )
-
-    # 2. Unlinked role scan
-    try:
-        from uph.party.controllers.unlinked_resolver import (
-            run_unlinked_issue_scan,
-        )
-
-        run_unlinked_issue_scan()
-        frappe.db.commit()
-    except Exception as e:
-        frappe.log_error(
-            title="Patch: unlinked role scan failed",
-            message=str(e),
-        )
-
-    # 3. Auto-resolve false-positive Unlinked issues
-    #    (records that have been linked to a Party Master after the issue was created)
+    # 1. Auto-resolve false-positive Unlinked issues
     try:
         _resolve_false_positive_unlinked_issues()
         frappe.db.commit()
     except Exception as e:
-        frappe.log_error(
-            title="Patch: resolve false-positive unlinked issues failed",
-            message=str(e),
-        )
+        frappe.log_error(title="Patch: resolve false-positive unlinked issues failed", message=str(e))
+
+    # 2. Auto-resolve false-positive Transaction Policy issues
+    try:
+        _resolve_false_positive_transaction_issues()
+        frappe.db.commit()
+    except Exception as e:
+        frappe.log_error(title="Patch: resolve false-positive transaction issues failed", message=str(e))
+
+    # 3. Transaction policy scan
+    try:
+        from uph.party.controllers.transaction_health import run_transaction_policy_scan
+        run_transaction_policy_scan()
+        frappe.db.commit()
+    except Exception as e:
+        frappe.log_error(title="Patch: transaction policy scan failed", message=str(e))
+
+    # 4. Unlinked role scan
+    try:
+        from uph.party.controllers.unlinked_resolver import run_unlinked_issue_scan
+        run_unlinked_issue_scan()
+        frappe.db.commit()
+    except Exception as e:
+        frappe.log_error(title="Patch: unlinked role scan failed", message=str(e))
 
     frappe.flags.in_patch = False
 
@@ -81,10 +75,7 @@ def _resolve_false_positive_unlinked_issues():
     """
     open_unlinked = frappe.get_all(
         "Party Issue",
-        filters={
-            "issue_type": "Unlinked",
-            "status": ["in", ["Open", "Under Review"]],
-        },
+        filters={"issue_type": "Unlinked", "status": ["in", ["Open", "Under Review"]]},
         fields=["name", "reference_doctype", "reference_name"],
         limit_page_length=0,
     )
@@ -108,37 +99,80 @@ def _resolve_false_positive_unlinked_issues():
             continue
 
         # Check if the record still exists
-        if not frappe.db.exists(dt, name):
-            # Record deleted — resolve the issue
-            frappe.db.set_value(
-                "Party Issue",
-                issue.name,
-                {
-                    "status": "Resolved",
-                    "resolved_on": now,
-                    "resolved_by": "Administrator",
-                },
-                update_modified=False,
-            )
-            resolved_count += 1
-            continue
-
         pm_val = frappe.db.get_value(dt, name, "party_master")
-        if pm_val:
-            # Already linked — this is a false positive, resolve it
-            frappe.db.set_value(
-                "Party Issue",
-                issue.name,
-                {
-                    "status": "Resolved",
-                    "resolved_on": now,
-                    "resolved_by": "Administrator",
-                },
-                update_modified=False,
-            )
+        if not frappe.db.exists(dt, name) or pm_val:
+            # Record deleted or Already linked — resolve it
+            frappe.db.set_value("Party Issue", issue.name, {
+                "status": "Resolved",
+                "resolved_on": now,
+                "resolved_by": "Administrator",
+            }, update_modified=False)
             resolved_count += 1
 
     if resolved_count:
-        frappe.logger().info(
-            f"Patch: resolved {resolved_count} false-positive Unlinked Party Issues"
-        )
+        frappe.logger().info(f"Patch: resolved {resolved_count} false-positive Unlinked Party Issues")
+
+
+def _resolve_false_positive_transaction_issues():
+    """
+    Find open Transaction Policy Party Issues where the referenced
+    voucher is no longer draft/cancelled/mismatched.
+    """
+    open_issues = frappe.get_all(
+        "Party Issue",
+        filters={"issue_type": "Transaction Policy", "status": ["in", ["Open", "Under Review"]]},
+        fields=["name", "reference_doctype", "reference_name", "details_json"],
+        limit_page_length=0,
+    )
+
+    if not open_issues:
+        return
+
+    resolved_count = 0
+    now = now_datetime()
+
+    for issue in open_issues:
+        dt = issue.reference_doctype
+        name = issue.reference_name
+        if not dt or not name or not frappe.db.exists("DocType", dt):
+            continue
+
+        details = {}
+        if issue.details_json:
+            try:
+                details = json.loads(issue.details_json)
+            except Exception:
+                pass
+        
+        issue_code = details.get("issue")
+        should_resolve = False
+
+        if not frappe.db.exists(dt, name):
+            should_resolve = True
+        else:
+            if issue_code == "draft_overdue":
+                docstatus = frappe.db.get_value(dt, name, "docstatus")
+                if docstatus != 0:
+                    should_resolve = True
+            elif issue_code == "cancelled_referenced":
+                docstatus = frappe.db.get_value(dt, name, "docstatus")
+                if docstatus != 2:
+                    should_resolve = True
+                else:
+                    meta = frappe.get_meta(dt)
+                    if meta.has_field("amended_from"):
+                        if frappe.db.get_value(dt, name, "amended_from"):
+                            should_resolve = True
+            # For mismatch, we might just let the next scan re-assess or keep it simple.
+            # Realistically, draft/cancelled cover 99% of false positives.
+
+        if should_resolve:
+            frappe.db.set_value("Party Issue", issue.name, {
+                "status": "Resolved",
+                "resolved_on": now,
+                "resolved_by": "Administrator",
+            }, update_modified=False)
+            resolved_count += 1
+
+    if resolved_count:
+        frappe.logger().info(f"Patch: resolved {resolved_count} false-positive Transaction Policy Issues")

--- a/uph/patches/rescan_transaction_health_and_unlinked.py
+++ b/uph/patches/rescan_transaction_health_and_unlinked.py
@@ -14,12 +14,16 @@ Steps
 2. Run ``run_unlinked_issue_scan()`` – creates Party Issue entries for
    role records (Customer, Supplier, Employee, …) that are not linked
    to a Party Master.
+3. Auto-resolve false-positive Unlinked issues where the referenced
+   record already has a ``party_master`` set (i.e. was linked after
+   the issue was created).
 
 Both scanners are idempotent (they call ``create_party_issue_if_missing``),
 so running them on a site that already has partial data is safe.
 """
 
 import frappe
+from frappe.utils import now_datetime
 
 
 def execute():
@@ -56,4 +60,85 @@ def execute():
             message=str(e),
         )
 
+    # 3. Auto-resolve false-positive Unlinked issues
+    #    (records that have been linked to a Party Master after the issue was created)
+    try:
+        _resolve_false_positive_unlinked_issues()
+        frappe.db.commit()
+    except Exception as e:
+        frappe.log_error(
+            title="Patch: resolve false-positive unlinked issues failed",
+            message=str(e),
+        )
+
     frappe.flags.in_patch = False
+
+
+def _resolve_false_positive_unlinked_issues():
+    """
+    Find open Unlinked Party Issues where the referenced record
+    already has party_master set, and mark them as Resolved.
+    """
+    open_unlinked = frappe.get_all(
+        "Party Issue",
+        filters={
+            "issue_type": "Unlinked",
+            "status": ["in", ["Open", "Under Review"]],
+        },
+        fields=["name", "reference_doctype", "reference_name"],
+        limit_page_length=0,
+    )
+
+    if not open_unlinked:
+        return
+
+    resolved_count = 0
+    now = now_datetime()
+
+    for issue in open_unlinked:
+        dt = issue.reference_doctype
+        name = issue.reference_name
+        if not dt or not name:
+            continue
+        if not frappe.db.exists("DocType", dt):
+            continue
+
+        meta = frappe.get_meta(dt)
+        if not meta.has_field("party_master"):
+            continue
+
+        # Check if the record still exists
+        if not frappe.db.exists(dt, name):
+            # Record deleted — resolve the issue
+            frappe.db.set_value(
+                "Party Issue",
+                issue.name,
+                {
+                    "status": "Resolved",
+                    "resolved_on": now,
+                    "resolved_by": "Administrator",
+                },
+                update_modified=False,
+            )
+            resolved_count += 1
+            continue
+
+        pm_val = frappe.db.get_value(dt, name, "party_master")
+        if pm_val:
+            # Already linked — this is a false positive, resolve it
+            frappe.db.set_value(
+                "Party Issue",
+                issue.name,
+                {
+                    "status": "Resolved",
+                    "resolved_on": now,
+                    "resolved_by": "Administrator",
+                },
+                update_modified=False,
+            )
+            resolved_count += 1
+
+    if resolved_count:
+        frappe.logger().info(
+            f"Patch: resolved {resolved_count} false-positive Unlinked Party Issues"
+        )

--- a/uph/patches/rescan_transaction_health_and_unlinked.py
+++ b/uph/patches/rescan_transaction_health_and_unlinked.py
@@ -1,0 +1,59 @@
+"""
+Post-migration patch: re-scan transaction health and unlinked roles.
+
+Previous implementation queried transaction tables on-the-fly for the
+dashboard.  The updated implementation reads from the Party Issue registry.
+This patch ensures all existing violations are recorded as Party Issue
+entries so the new dashboard shows correct data.
+
+Steps
+-----
+1. Run ``run_transaction_policy_scan()`` – creates Party Issue entries
+   for draft-overdue, cancelled-referenced, and party-master-mismatch
+   vouchers that have not yet been registered.
+2. Run ``run_unlinked_issue_scan()`` – creates Party Issue entries for
+   role records (Customer, Supplier, Employee, …) that are not linked
+   to a Party Master.
+
+Both scanners are idempotent (they call ``create_party_issue_if_missing``),
+so running them on a site that already has partial data is safe.
+"""
+
+import frappe
+
+
+def execute():
+    if not frappe.db.exists("DocType", "Party Issue"):
+        return
+
+    frappe.flags.in_patch = True
+
+    # 1. Transaction policy scan
+    try:
+        from uph.party.controllers.transaction_health import (
+            run_transaction_policy_scan,
+        )
+
+        run_transaction_policy_scan()
+        frappe.db.commit()
+    except Exception as e:
+        frappe.log_error(
+            title="Patch: transaction policy scan failed",
+            message=str(e),
+        )
+
+    # 2. Unlinked role scan
+    try:
+        from uph.party.controllers.unlinked_resolver import (
+            run_unlinked_issue_scan,
+        )
+
+        run_unlinked_issue_scan()
+        frappe.db.commit()
+    except Exception as e:
+        frappe.log_error(
+            title="Patch: unlinked role scan failed",
+            message=str(e),
+        )
+
+    frappe.flags.in_patch = False


### PR DESCRIPTION
Summary of changes:
- Improved stats cards with Frappe number-card style and clickable routes.
- Added Party Master filter field on the dashboard.
- Fixed unlinked vouchers tab to query transaction tables directly (using UNION ALL across transaction doctypes).
- Enhanced transaction health aggregation to group by (party, reference_doctype).
- Implemented per-doctype severity logic based on 'warn_not_submitted_document' in Party Master Settings.
- Updated Party workspace to include the 'Accounts Manager' role.