### PR TITLE
Docs: Add UPH documentation modernization blueprint, AI action buttons, and mobile navigation UX

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,23 +2,29 @@ name: Build and Deploy Hugo Docs
 
 on:
   push:
-    branches:
-      - docs
-    paths:
-      - "**" # trigger on any change in docs branch (optional refine)
+    branches: ["main", "docs", "work"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
-
     steps:
-      - name: Checkout docs branch
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -29,10 +35,18 @@ jobs:
       - name: Build site
         run: hugo --minify
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./public
-          keep_files: false
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -100,3 +100,73 @@ body,
   .doc-ai-actions { justify-content: flex-start; }
 }
 
+
+.doc-page-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.doc-action-btn {
+  border: 1px solid #e4e4e7;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  text-decoration: none;
+  font-size: 0.82rem;
+  font-weight: 600;
+  background: #fff;
+  color: #18181b;
+}
+
+.doc-action-btn.chatgpt:hover { border-color: #10a37f; }
+.doc-action-btn.claude:hover { border-color: #9333ea; }
+.doc-action-btn.edit:hover { border-color: #2563eb; }
+
+.mobile-doc-nav { display: none; }
+
+@media (max-width: 900px) {
+  .mobile-doc-nav {
+    display: block;
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 0.9rem;
+    z-index: 60;
+  }
+
+  .mobile-doc-nav__trigger {
+    border: none;
+    border-radius: 999px;
+    background: #111827;
+    color: #fff;
+    padding: 0.7rem 1rem;
+    font-weight: 700;
+    box-shadow: 0 8px 24px rgba(0,0,0,.25);
+  }
+
+  .mobile-doc-nav__sheet {
+    position: fixed;
+    left: 1rem;
+    right: 1rem;
+    bottom: 4.2rem;
+    background: #fff;
+    border: 1px solid #e4e4e7;
+    border-radius: 1rem;
+    box-shadow: 0 20px 40px rgba(0,0,0,.18);
+    padding: 0.75rem;
+  }
+
+  .mobile-doc-nav__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.6rem;
+  }
+
+  .mobile-doc-nav__content a {
+    display: block;
+    padding: 0.45rem 0.25rem;
+    text-decoration: none;
+  }
+}

--- a/content.en/docs/recreated/_index.md
+++ b/content.en/docs/recreated/_index.md
@@ -23,3 +23,4 @@ This section was rebuilt from static analysis of the UPH Python bytecode and the
 2. [Architecture, Domain Model, and Workflows](./architecture-and-domain-model.md)
 3. [Installation, Setup, and Configuration](./installation-configuration-usage.md)
 4. [APIs, Hooks, Security, Extensibility, and Limitations](./api-hooks-security-extensibility.md)
+5. [UPH Documentation Modernization Blueprint](./uph-docs-modernization-blueprint.md)

--- a/content.en/docs/recreated/uph-docs-modernization-blueprint.md
+++ b/content.en/docs/recreated/uph-docs-modernization-blueprint.md
@@ -1,0 +1,201 @@
+---
+title: "UPH Documentation Modernization Blueprint"
+weight: 6
+---
+
+# 1) Full develop branch audit report (available snapshot)
+
+> **Constraint:** this repository snapshot contains UPH Python bytecode (`.pyc`) but not editable `.py` module sources; therefore the backend audit is based on documented API references + reconstructed notes in this docs tree.
+
+## Branch and codebase findings
+
+- Current local git branch: `work`.
+- No remote-tracking `develop` branch exists in this environment.
+- Frappe app source modules are absent in plaintext (`uph/**` is bytecode-heavy).
+
+## Architecture map (inferred)
+
+### DocTypes (new/modified)
+- Party Master
+- Party Master Role
+- Party Master Parties
+- Party Master Accounts
+- Party Master Settings (+ child doctypes)
+- Party Analytic Accounting (+ child doctypes)
+- Data Quality Rule + Rule Condition
+- Duplicate-exclusion support for merge workflow
+
+### Backend Python modules
+- `uph.party.controllers.party`
+- `uph.party.controllers.queries`
+- `uph.party.controllers.mdm`
+- `uph.party.boot`
+- `uph.party.setup`
+- `uph.regional.arabic`
+
+### Frontend / Desk components
+- Data Quality Dashboard page handlers
+- DocType form scripts and query hooks
+- Tree view support for Party Master
+
+### Hooks and overrides
+- `before_validate` propagation of `party_master` link to configured transactional doctypes
+- validation/update/change/trash events for synchronization and consistency checks
+- optional override for party details API behavior
+
+### Whitelisted surface (documented)
+- `uph.party.controllers.party.get_party_details`
+- `uph.party.controllers.party.set_party_master`
+- `uph.party.controllers.mdm.validate_document_quality`
+- dashboard APIs for duplicate detection, merge, dismiss, stats
+
+### Patches / migration behavior (inferred)
+- install/boot routines create and map fields
+- migration-safe bypass branches during patch/import contexts
+- queued updates for large transaction backfill
+
+### REST / RPC endpoints
+- Frappe RPC via `frappe.call` to whitelisted methods
+- desk dashboard AJAX calls (duplicate engine + stats)
+
+---
+
+# 2) Reverse-engineering notes: docs.frappe.io (mobile)
+
+## Observed stack traits
+
+- Styling and UI classes indicate Tailwind utility CSS.
+- Runtime behavior uses Alpine.js plugins (`persist`, `collapse`) and code-highlighting bundles.
+- Route shape is path-based content routing (`/framework/user/en/...`) with deep hierarchy.
+- Search input appears embedded in docs UI and links to search-related API/docs routes.
+
+## UX and layout observations
+
+- Left sidebar uses deeply nested page tree with section grouping.
+- Mobile uses compact navigation behavior rather than classic desktop persistent sidebar.
+- Content page = title + article body + contextual nav links.
+- Multi-product shell (Framework, ERPNext, HR, Cloud, etc.) is top-level IA.
+
+## SSG/CMS inference
+
+- Most likely Frappe’s own docs/wiki rendering system (not plain MkDocs/Docusaurus/Hugo defaults).
+- Markdown-to-HTML appears integrated with app templates and server-rendered route handlers.
+- “Edit” linkage likely computed from source path metadata per page.
+
+---
+
+# 3) UPH documentation architecture blueprint (implemented direction)
+
+## Chosen generator: **Hugo (Book theme + overrides)**
+
+### Why Hugo over alternatives
+- Already used by UPH docs branch (lowest migration risk).
+- Fast build for multilingual docs and large tree scale.
+- Template partial system is strong for reusable header/sidebar/footer/content patterns.
+- Easy GitHub Pages automation with deterministic static output.
+
+### Required UX capabilities and status
+- Sidebar navigation tree: **existing (theme + menu/tree partials)**
+- Breadcrumbs: **implemented in `single.html`**
+- Mobile bottom popup navigation: **implemented via `mobile-doc-nav` sheet**
+- Search: **existing via Book search index**
+- Per-page actions: **implemented with GitHub + ChatGPT + Claude buttons**
+
+---
+
+# 4) Smart page action buttons design
+
+## URL logic
+
+- Edit on GitHub:
+  - `https://github.com/<org>/<repo>/edit/docs/content.<lang>/<relative-path>.md`
+- ChatGPT:
+  - `https://chatgpt.com/?q=<urlencoded_prompt>`
+- Claude:
+  - `https://claude.ai/new?q=<urlencoded_prompt>`
+
+## Encoding and security strategy
+
+- Use `encodeURIComponent` for prompt payload.
+- Trim normalized page text before URL composition.
+- Open with `noopener,noreferrer`.
+- Avoid injecting raw HTML; use plain text from `innerText`/summary.
+
+## Oversize fallback
+
+- If generated URL crosses threshold, store prompt in `sessionStorage` and copy to clipboard.
+- Open provider with short bootstrap prompt telling user to paste/carry full context.
+
+---
+
+# 5) GitHub Actions CI/CD example (GitHub Pages)
+
+- Trigger on docs-relevant branches.
+- Build Hugo static site.
+- Upload artifact.
+- Deploy through `actions/deploy-pages`.
+
+(See `.github/workflows/deploy.yml` in this repo for concrete implementation.)
+
+---
+
+# 6) Folder structure proposal
+
+```text
+content.en/docs/
+  introduction/
+  features/
+  usecases/
+  Advanced/
+  recreated/
+
+layouts/
+  _default/single.html
+  _partials/docs/
+    ai-page-actions.html
+    menu.html
+
+static/
+  custom.css
+  css/landing.css
+```
+
+---
+
+# 7) Migration & rollout plan
+
+1. Extract current docs content from branch snapshot and normalize naming.
+2. Enforce hierarchy by domain (intro, features, use-cases, advanced, recreated/audit).
+3. Standardize front matter (`title`, `weight`, optional `bookCollapseSection`).
+4. Apply shared templates/partials for page wrapper and actions.
+5. Enable mobile popup navigation and validate with viewport QA.
+6. Verify GitHub edit links for multilingual paths.
+7. Roll out AI buttons with URL-size fallback logic.
+8. Enable CI build + Pages deployment.
+9. Establish version strategy:
+   - `main` = latest stable docs
+   - `release/x.y` = frozen docs
+   - optional `/v/<version>/` multilingual subpaths.
+
+---
+
+# 8) Risk & security matrix
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---:|---:|---|
+| Missing plaintext backend source | High | Medium | Treat reconstructed audit as provisional; restore `.py` source in repo |
+| AI prompt URL overflow | Medium | High | sessionStorage + clipboard fallback |
+| Broken edit links after path refactors | Medium | Medium | generate URL from `.File.Path`; add CI link checker |
+| Search index drift | Medium | Low | rebuild index per deploy; smoke-test top queries |
+| Mobile nav overlap with theme UI | Low | Medium | media-query scope + visual QA per breakpoint |
+| Unauthorized docs edits | Medium | Medium | protect docs branches + PR reviews + CODEOWNERS |
+
+---
+
+# 9) Long-term maintainability strategy
+
+- Keep docs-as-code governance: PR templates, linting, CODEOWNERS.
+- Add markdown lint + link checker in CI.
+- Keep templates minimal and centralized in partials.
+- Introduce docs versioning policy aligned to UPH releases.
+- Track architecture drift with quarterly backend-doc reconciliation.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,4 +24,41 @@
     {{ end }}
   </nav>
 </article>
+
+<div class="mobile-doc-nav" data-mobile-doc-nav>
+  <button class="mobile-doc-nav__trigger" data-mobile-doc-nav-open aria-label="Open page navigation">Page Navigation</button>
+  <div class="mobile-doc-nav__sheet" data-mobile-doc-nav-sheet hidden>
+    <div class="mobile-doc-nav__header">
+      <strong>Navigate</strong>
+      <button data-mobile-doc-nav-close aria-label="Close page navigation">✕</button>
+    </div>
+    <div class="mobile-doc-nav__content">
+      {{ with .PrevInSection }}<a href="{{ .RelPermalink }}">← {{ .LinkTitle }}</a>{{ end }}
+      {{ with .NextInSection }}<a href="{{ .RelPermalink }}">{{ .LinkTitle }} →</a>{{ end }}
+      <a href="#" data-scroll-top>Back to top</a>
+      <a href="{{ "#TableOfContents" }}">Table of contents</a>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  const root = document.querySelector('[data-mobile-doc-nav]');
+  if (!root) return;
+  const sheet = root.querySelector('[data-mobile-doc-nav-sheet]');
+  const openBtn = root.querySelector('[data-mobile-doc-nav-open]');
+  const closeBtn = root.querySelector('[data-mobile-doc-nav-close]');
+
+  const open = () => { sheet.hidden = false; root.classList.add('is-open'); };
+  const close = () => { sheet.hidden = true; root.classList.remove('is-open'); };
+
+  openBtn?.addEventListener('click', open);
+  closeBtn?.addEventListener('click', close);
+  sheet?.querySelector('[data-scroll-top]')?.addEventListener('click', (event) => {
+    event.preventDefault();
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    close();
+  });
+})();
+</script>
 {{ end }}

--- a/layouts/_partials/docs/ai-page-actions.html
+++ b/layouts/_partials/docs/ai-page-actions.html
@@ -1,70 +1,96 @@
 {{- $title := .Title -}}
 {{- $url := .Permalink -}}
 {{- $summary := .Summary | plainify -}}
+{{- $editUrl := "" -}}
+{{- with .File -}}
+  {{- $editUrl = printf "%s/edit/docs/content.%s/%s" $.Site.Params.BookRepo $.Lang .Path -}}
+{{- end -}}
 
-<div class="doc-ai-actions" data-page-title="{{ $title | htmlEscape }}" data-page-url="{{ $url | safeURL }}" data-page-summary="{{ $summary | htmlEscape }}">
-  <a class="doc-ai-btn chatgpt" href="#" data-ai="chatgpt" rel="noopener noreferrer" target="_blank" aria-label="Ask ChatGPT">
-    <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2a4.6 4.6 0 0 1 4.57 4.12 4.58 4.58 0 0 1 3.35 1.33 4.63 4.63 0 0 1-.09 6.56 4.59 4.59 0 0 1-.82 5.48 4.58 4.58 0 0 1-5.48.82A4.63 4.63 0 0 1 7 20.22a4.58 4.58 0 0 1-1.33-3.35A4.6 4.6 0 0 1 1.55 12a4.6 4.6 0 0 1 4.12-4.57A4.6 4.6 0 0 1 12 2m-.15 2.2a2.4 2.4 0 0 0-2.3 1.82l-.14.54-.55.03a2.4 2.4 0 0 0-1.35 4.3l.43.34-.17.52a2.4 2.4 0 0 0 3.11 3l.5-.2.37.38a2.4 2.4 0 0 0 4-2.14l.02-.55.52-.17a2.4 2.4 0 0 0-.72-4.71l-.55-.04-.14-.53a2.4 2.4 0 0 0-2.33-1.8Z"/></svg>
-    <span>Ask ChatGPT</span>
+<div class="doc-page-actions" data-page-title="{{ $title | htmlEscape }}" data-page-url="{{ $url | safeURL }}" data-page-summary="{{ $summary | htmlEscape }}">
+  {{ if $editUrl }}
+  <a class="doc-action-btn edit" href="{{ $editUrl | safeURL }}" rel="noopener noreferrer" target="_blank" aria-label="Edit this page on GitHub">
+    <span>Edit on GitHub</span>
   </a>
-
-  <a class="doc-ai-btn gemini" href="#" data-ai="gemini" rel="noopener noreferrer" target="_blank" aria-label="Ask Gemini">
-    <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2l2.1 5.8L20 10l-5.9 2.2L12 18l-2.1-5.8L4 10l5.9-2.2z"/></svg>
-    <span>Ask Gemini</span>
+  {{ end }}
+  <a class="doc-action-btn chatgpt" href="#" data-ai="chatgpt" rel="noopener noreferrer" target="_blank" aria-label="Open this page in ChatGPT">
+    <span>Open in ChatGPT</span>
   </a>
-
-  <a class="doc-ai-btn claude" href="#" data-ai="claude" rel="noopener noreferrer" target="_blank" aria-label="Ask Claude">
-    <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 3c4.8 0 8.7 3.9 8.7 8.7 0 4.8-3.9 8.7-8.7 8.7-4.8 0-8.7-3.9-8.7-8.7C3.3 6.9 7.2 3 12 3m0 2.2a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13m-.2 2.2a1.1 1.1 0 0 1 1.1 1.1v2.5h2.5a1.1 1.1 0 1 1 0 2.2h-2.5v2.5a1.1 1.1 0 1 1-2.2 0v-2.5H8.2a1.1 1.1 0 0 1 0-2.2h2.5V8.5a1.1 1.1 0 0 1 1.1-1.1"/></svg>
-    <span>Ask Claude</span>
+  <a class="doc-action-btn claude" href="#" data-ai="claude" rel="noopener noreferrer" target="_blank" aria-label="Open this page in Claude">
+    <span>Open in Claude</span>
   </a>
 </div>
 
 <script>
 (function () {
-  const container = document.querySelector('.doc-ai-actions');
+  const container = document.querySelector('.doc-page-actions');
   if (!container) return;
 
+  const MAX_URL_LEN = 3500;
+  const SESSION_KEY = 'uph-doc-ai-prompt';
   const providers = {
     chatgpt: (prompt) => `https://chatgpt.com/?q=${encodeURIComponent(prompt)}`,
-    gemini: (prompt) => `https://gemini.google.com/app?prompt=${encodeURIComponent(prompt)}`,
-    claude: (prompt) => `https://claude.ai/new?q=${encodeURIComponent(prompt)}`
+    claude: (prompt) => `https://claude.ai/new?q=${encodeURIComponent(prompt)}`,
   };
 
-  function trimText(text, maxLen) {
-    if (!text) return '';
-    const cleaned = String(text).replace(/\s+/g, ' ').trim();
-    return cleaned.length > maxLen ? `${cleaned.slice(0, maxLen)}…` : cleaned;
-  }
+  const trim = (text, limit) => {
+    const val = String(text || '').replace(/\s+/g, ' ').trim();
+    return val.length > limit ? `${val.slice(0, limit)}…` : val;
+  };
 
   function buildPrompt() {
     const title = container.dataset.pageTitle || document.title;
     const pageUrl = container.dataset.pageUrl || window.location.href;
     const summary = container.dataset.pageSummary || '';
-    const pageText = document.querySelector('article.book-article')?.innerText || '';
-    const context = trimText(pageText || summary, 2200);
+    const body = document.querySelector('article.book-article')?.innerText || summary;
+    const context = trim(body, 4500);
 
     return [
-      'Help me with this documentation page.',
+      'Please improve this UPH documentation page.',
       `Title: ${title}`,
       `URL: ${pageUrl}`,
       '',
-      'Context:',
-      context,
+      'Tasks:',
+      '1) Rewrite for clarity and architecture accuracy.',
+      '2) Suggest missing implementation details and risks.',
+      '3) Keep examples practical for Frappe/ERPNext teams.',
       '',
-      'Please summarize key points and provide practical implementation guidance.'
+      'Page content:',
+      context,
     ].join('\n');
+  }
+
+  function safeOpen(providerName) {
+    const prompt = buildPrompt();
+    const provider = providers[providerName];
+    if (!provider) return;
+
+    const link = provider(prompt);
+    if (link.length <= MAX_URL_LEN) {
+      window.open(link, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
+    try {
+      sessionStorage.setItem(SESSION_KEY, prompt);
+      navigator.clipboard?.writeText(prompt).catch(() => {});
+    } catch (error) {
+      navigator.clipboard?.writeText(prompt).catch(() => {});
+    }
+
+    const shortPrompt = [
+      'I copied the full UPH docs page context to clipboard/sessionStorage.',
+      'Please ask me to paste it if not visible.',
+      `Page: ${container.dataset.pageTitle || document.title}`,
+      `URL: ${container.dataset.pageUrl || window.location.href}`
+    ].join('\n');
+
+    window.open(provider(shortPrompt), '_blank', 'noopener,noreferrer');
   }
 
   container.querySelectorAll('[data-ai]').forEach((button) => {
     button.addEventListener('click', (event) => {
       event.preventDefault();
-      const prompt = buildPrompt();
-      const provider = providers[button.dataset.ai];
-      if (!provider) return;
-      window.open(provider(prompt), '_blank', 'noopener,noreferrer');
-      if (button.dataset.ai === 'gemini' && navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(prompt).catch(() => {});
-      }
+      safeOpen(button.dataset.ai);
     });
   });
 })();

--- a/static/custom.css
+++ b/static/custom.css
@@ -167,3 +167,73 @@ body,
 .doc-ai-btn.claude {
   border-color: #9333ea33;
 }
+
+.doc-page-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.doc-action-btn {
+  border: 1px solid #e4e4e7;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  text-decoration: none;
+  font-size: 0.82rem;
+  font-weight: 600;
+  background: #fff;
+  color: #18181b;
+}
+
+.doc-action-btn.chatgpt:hover { border-color: #10a37f; }
+.doc-action-btn.claude:hover { border-color: #9333ea; }
+.doc-action-btn.edit:hover { border-color: #2563eb; }
+
+.mobile-doc-nav { display: none; }
+
+@media (max-width: 900px) {
+  .mobile-doc-nav {
+    display: block;
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 0.9rem;
+    z-index: 60;
+  }
+
+  .mobile-doc-nav__trigger {
+    border: none;
+    border-radius: 999px;
+    background: #111827;
+    color: #fff;
+    padding: 0.7rem 1rem;
+    font-weight: 700;
+    box-shadow: 0 8px 24px rgba(0,0,0,.25);
+  }
+
+  .mobile-doc-nav__sheet {
+    position: fixed;
+    left: 1rem;
+    right: 1rem;
+    bottom: 4.2rem;
+    background: #fff;
+    border: 1px solid #e4e4e7;
+    border-radius: 1rem;
+    box-shadow: 0 20px 40px rgba(0,0,0,.18);
+    padding: 0.75rem;
+  }
+
+  .mobile-doc-nav__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.6rem;
+  }
+
+  .mobile-doc-nav__content a {
+    display: block;
+    padding: 0.45rem 0.25rem;
+    text-decoration: none;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a reproducible modernization blueprint and audit for the UPH docs site to support the requested migration, architecture mapping, and rollout plan. 
- Improve author and reader workflows by adding per-page AI-assisted action buttons (Edit on GitHub, Open in ChatGPT, Open in Claude) that carry page context securely. 
- Recreate Frappe-like mobile UX by adding a bottom popup page navigation and ensure the docs site is deployable via a robust GitHub Actions Pages pipeline.

### Description

- Added a new blueprint document at `content.en/docs/recreated/uph-docs-modernization-blueprint.md` and linked it from `content.en/docs/recreated/_index.md` to capture the full audit, migration plan, risk matrix, generator recommendation, and maintainability strategy. 
- Implemented reusable AI page actions in `layouts/_partials/docs/ai-page-actions.html` that build a URL-safe prompt, use `encodeURIComponent`, and apply a prompt-size fallback which stores the full prompt in `sessionStorage` and copies it to the clipboard if it exceeds the URL length threshold. 
- Implemented mobile bottom popup navigation and page navigation controls in `layouts/_default/single.html` with small JavaScript to open/close the sheet and provide Prev/Next/ToC/Top links. 
- Added styling for the new controls and mobile sheet in both `static/custom.css` and `assets/custom.css`. 
- Updated CI to an artifacts-and-deploy-pages flow for GitHub Pages in `.github/workflows/deploy.yml` using `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` with appropriate permissions.

### Testing

- Captured a mobile viewport screenshot of `https://docs.frappe.io/framework/user/en/introduction` using a Playwright script to inform reverse-engineering and UX parity work; this run completed successfully and yielded an artifact. 
- Attempted a local site build with `hugo --minify`, which failed in this environment because the `hugo` binary is not installed (automated build could not be validated locally). 
- Attempted a local Playwright navigation against `http://127.0.0.1:1313/en/docs/introduction/` which failed with `ERR_EMPTY_RESPONSE` because no local Hugo dev server was running in the environment. 
- Performed repository scans and static checks (file diffs and content updates) to verify partials, templates, and markdown were written and linked as expected (no automated CI-run was executed here; workflow file added to enable CI on push).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6fa18a18832b9731334bc0810ee4)