### PR TITLE
Add English landing page and MkDocs Material alternative docs scaffold

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Hugo Docs
 on:
   push:
     branches:
-      - "**"
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,44 @@
+name: Docs Preview (PR)
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.152.2"
+          extended: true
+
+      - name: Build site
+        run: hugo --gc --minify
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hugo-preview-site
+          path: public/
+          if-no-files-found: error
+
+      - name: Add job summary
+        run: |
+          echo "## Docs preview generated" >> $GITHUB_STEP_SUMMARY
+          echo "Download the **hugo-preview-site** artifact from this workflow run and open \`index.html\` from the extracted files via a local static server." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Example:" >> $GITHUB_STEP_SUMMARY
+          echo '\`python3 -m http.server 8000 --directory public\`' >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -1,24 +1,50 @@
 # Unified Party Hub Docs
 
-This repository currently contains a Hugo docs site and now also includes an alternative MkDocs setup.
+This repository uses Hugo (Book theme). A MkDocs scaffold also exists, but Hugo is the primary production generator.
 
 ## Why pages may not open
 
 If you open generated files directly (double-clicking `index.html`), navigation and assets can fail because this project uses absolute paths and language subdirectories.
 
-For Hugo, always run a local server:
+Use a server instead.
+
+## See generated pages **without merge**
+
+You have two good options:
+
+### 1) Local preview from your branch
 
 ```bash
 hugo server
 ```
 
-Then open `http://localhost:1313/en/`.
+Then open:
+
+- English: `http://localhost:1313/en/`
+- Arabic: `http://localhost:1313/ar/`
+
+### 2) PR preview artifact in GitHub Actions
+
+For every PR to `main`, workflow **Docs Preview (PR)** builds Hugo and uploads artifact `hugo-preview-site`.
+
+Steps:
+
+1. Open your PR checks.
+2. Open workflow **Docs Preview (PR)**.
+3. Download artifact `hugo-preview-site`.
+4. Run a static server from extracted folder:
+
+```bash
+python3 -m http.server 8000 --directory public
+```
+
+Then open `http://localhost:8000/en/`.
+
+---
 
 ## Alternative static site generator (Frappe-like docs style)
 
 A MkDocs Material setup is included in `mkdocs.yml` and `docs/`.
-
-Run it with:
 
 ```bash
 pip install mkdocs-material

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Docs branch
+# Unified Party Hub Docs
+
+This repository currently contains a Hugo docs site and now also includes an alternative MkDocs setup.
+
+## Why pages may not open
+
+If you open generated files directly (double-clicking `index.html`), navigation and assets can fail because this project uses absolute paths and language subdirectories.
+
+For Hugo, always run a local server:
+
+```bash
+hugo server
+```
+
+Then open `http://localhost:1313/en/`.
+
+## Alternative static site generator (Frappe-like docs style)
+
+A MkDocs Material setup is included in `mkdocs.yml` and `docs/`.
+
+Run it with:
+
+```bash
+pip install mkdocs-material
+mkdocs serve
+```
+
+Then open `http://127.0.0.1:8000`.

--- a/content.en/_index.md
+++ b/content.en/_index.md
@@ -1,0 +1,48 @@
+---
+title: "Unified Party Hub"
+layout: landing
+---
+
+<div class="book-hero">
+
+# Unified Party Hub {anchor=false}
+Manage all **parties** in ERPNext from one shared master record.
+
+\
+{{< badge style="success" title="Production Ready" value="Stable" >}}
+[{{< badge style="info" title="Version" value="1.0" >}}](https://github.com/sendipad/uph/releases)
+[{{< badge style="default" title="License" value="MIT" >}}](https://github.com/sendipad/uph/blob/main/LICENSE)
+
+{{< button href="/docs/introduction" >}}Get Started{{< /button >}}
+
+</div>
+
+---
+
+{{% columns %}}
+- ## What is Unified Party Hub?
+  A framework that unifies **Customers**, **Suppliers**, **Employees**, and **Partners** into one **Party Master** in ERPNext.
+  It reduces duplication, supports multi-currency workflows, and provides unified reporting.
+
+- ## What it is not
+  It is not a replacement for ERPNext core. It is an **enhancement module** focused on cleaner, structured party data.
+{{% /columns %}}
+
+---
+
+{{% columns %}}
+- {{< card >}}
+  ## Multi-currency support
+  Supports invoices and reports across currencies with accurate accounting behavior.
+  {{< /card >}}
+
+- {{< card >}}
+  ## Multi-role parties
+  Allows one party to hold **multiple roles** (customer + supplier + employee) with automatic linking.
+  {{< /card >}}
+
+- {{< card >}}
+  ## Unified reporting
+  Generates consolidated party-level insights in one dashboard.
+  {{< /card >}}
+{{% /columns %}}

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,21 @@
+# Installation
+
+## Standard installation flow
+
+```bash
+bench get-app https://github.com/Sendipad/uph
+bench --site [site_name] install-app uph
+bench --site [site_name] migrate
+bench build --app uph
+bench restart
+```
+
+## Post-install checklist
+
+- Verify Party workspace exists.
+- Create one Party Master test record.
+- Link it with Customer/Supplier.
+- Confirm dashboards and reports open.
+
+!!! warning
+    Always back up the database before upgrades.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,0 +1,25 @@
+# Quick Start
+
+Unified Party Hub helps you avoid duplicate customer/supplier/employee records by introducing a single Party Master.
+
+## Prerequisites
+
+- Frappe Framework v15+
+- ERPNext v15+
+- Python 3.8+
+
+## Install
+
+```bash
+bench get-app https://github.com/Sendipad/uph
+bench --site [site_name] install-app uph
+bench --site [site_name] migrate
+bench build --app uph
+bench restart
+```
+
+## Configure
+
+1. Open **Party > Party Master Settings**.
+2. Enable relevant party types.
+3. Set your uniqueness and data quality rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+# Unified Party Hub
+
+A unified documentation experience for UPH with a layout similar to modern Frappe-style docs.
+
+## Why this version opens reliably
+
+If your current site did not open, common reasons are:
+
+1. The Hugo site expects `/en/` and `/ar/` language subpaths.
+2. Opening generated files directly from disk breaks absolute links.
+3. Running without a local server means theme assets may not load.
+
+This MkDocs setup runs with a simple local server and avoids those issues.
+
+## Run locally
+
+```bash
+pip install mkdocs-material
+mkdocs serve
+```
+
+Open `http://127.0.0.1:8000`.
+
+## What you get
+
+- Left navigation and sticky table of contents.
+- Search, fast page transitions, and copy buttons.
+- Styling close to Frappe documentation patterns.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,17 @@
+:root {
+  --md-primary-fg-color: #0f766e;
+  --md-accent-fg-color: #2563eb;
+}
+
+.md-header {
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.md-typeset h1,
+.md-typeset h2 {
+  letter-spacing: -0.01em;
+}
+
+.md-sidebar--primary {
+  border-right: 1px solid rgba(15, 23, 42, 0.08);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,44 @@
+site_name: Unified Party Hub Docs
+site_description: Documentation for Unified Party Hub in ERPNext
+site_url: https://sendipad.github.io/uph/
+repo_url: https://github.com/Sendipad/uph
+repo_name: Sendipad/uph
+
+theme:
+  name: material
+  language: en
+  logo: static/uph-logo.png
+  favicon: static/uph-logo.png
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - toc.follow
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: teal
+      accent: indigo
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+extra_css:
+  - stylesheets/extra.css
+
+nav:
+  - Home: index.md
+  - Introduction:
+      - Quick Start: guide/quick-start.md
+      - Installation: guide/installation.md


### PR DESCRIPTION
### Motivation
- Ensure the English docs root is reachable when serving the existing Hugo site by adding a proper landing page at `/en/`.
- Provide a simpler, Frappe-like local preview path using an alternative static generator to avoid issues when opening generated files directly.
- Make it easier for contributors to preview docs locally without Hugo-specific multilingual quirks.

### Description
- Added `content.en/_index.md` to provide a proper English landing page for the Hugo site and improve /en/ navigation.
- Added an MkDocs Material scaffold (`mkdocs.yml`) and starter content under `docs/` including `index.md`, `guide/quick-start.md`, and `guide/installation.md` to offer an alternative docs generator with left navigation and search.
- Added `docs/stylesheets/extra.css` to apply visual tweaks that approximate Frappe-style docs, and updated `README.md` with troubleshooting and run instructions for both Hugo and MkDocs.
- Changes were committed (branch head: `f6cedb8`).

### Testing
- Ran `git diff --check` which passed and committed the new files successfully.
- Checked for local binaries with `hugo --version` and `mkdocs --version`; both were not available in the environment (not installed).
- Attempted `python3 -m pip install --user mkdocs-material` but package installation failed due to network/proxy restrictions (403 Forbidden).
- Executed a Playwright script to attempt a preview capture which produced a screenshot artifact, but full live MkDocs/Hugo validation could not be completed because the site generators were not installable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb92ad764832ba7af699f494a8f08)