### PR TITLE
docs: add html homepages and deploy workflow

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Unified Party Hub — Home</title>
+  <style>
+    body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial; margin: 2.5rem; color: #111 }
+    header { margin-bottom: 1.5rem }
+    a.button { display:inline-block; margin: .4rem .25rem; padding: .5rem .9rem; background:#0366d6; color:#fff; text-decoration:none; border-radius:6px }
+    .muted { color:#666 }
+    pre { background:#f6f8fa; padding:1rem; border-radius:6px; overflow:auto }
+    footer { margin-top:2rem; color:#666; font-size:0.95rem }
+    h1,h2 { color:#0b3d91 }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Unified Party Hub (UPH)</h1>
+    <p class="muted">Documentation and resources for the UPH app for ERPNext.</p>
+    <p>
+      <a class="button" href="https://github.com/Sendipad/uph">Repository</a>
+      <a class="button" href="https://github.com/Sendipad/uph/issues">Issues</a>
+    </p>
+  </header>
+
+  <main>
+    <section>
+      <h2>Overview</h2>
+      <p>Unified Party Hub centralizes the management of parties (customers, suppliers, contacts) in ERPNext, linking documents, accounts, and workflows.</p>
+    </section>
+
+    <section>
+      <h2>Key Features</h2>
+      <ul>
+        <li>Unified party record across multiple DocTypes.</li>
+        <li>Enhanced search and filters.</li>
+        <li>Quick links to related documents (invoices, purchase orders, contracts).</li>
+        <li>Customizable settings per company.</li>
+        <li>Automated workflows triggered by updates to parties.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Installation</h2>
+      <p>Clone the repository into your <code>apps</code> folder and install:</p>
+      <pre><code>bench get-app https://github.com/Sendipad/uph
+bench --site yoursite install-app unified_party_hub
+</code></pre>
+    </section>
+
+    <section>
+      <h2>Arabic Version</h2>
+      <p>The repository contains Arabic docs (docs/index_ar.md). The Arabic homepage is also included as <code>docs/index_ar.html</code> so visitors can switch languages.</p>
+      <p><a href="./index_ar.html" class="button">العربية</a></p>
+    </section>
+
+  </main>
+
+  <footer>
+    <p>Generated from <code>docs/index.md</code> in the repository.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds static HTML homepages (English and Arabic) and a GitHub Actions workflow to publish the `docs/` folder to `gh-pages`. This enables GitHub Pages to serve a ready HTML site for the repository.

## Changes

- `docs/index.html` — English homepage (converted from `docs/index.md`)
- `docs/index_ar.html` — Arabic homepage (converted from `docs/index_ar.md`)
- `.github/workflows/deploy-pages.yml` — Action to publish `./docs` to `gh-pages` when the `docs` branch receives a push

## Why

- The repository previously lacked an HTML entrypoint for GitHub Pages.
- Committing HTML ensures a predictable site (no Jekyll/build required).
- The deploy workflow automates publishing and keeps the live site in sync with `docs/`.

## How to test (recommended)

1. Merge this branch into the `docs` branch (or directly push these files to `docs`).
2. Confirm the Actions workflow runs for the `docs` push and completes successfully.
3. In the repository Settings → Pages, ensure the source is set to the `gh-pages` branch (root).
4. Visit: `https://sendipad.github.io/uph/` and verify:
   - The English homepage is at `/` (served from `docs/index.html` published to `gh-pages`)
   - The Arabic homepage is available at `/index_ar.html`

## Merge & Publish steps (recommended)

- Option A (recommended): Create PR pages-fix → docs and merge. The deploy workflow is configured to trigger on pushes to `docs`, so merging into `docs` will publish automatically.
- Option B: Merge pages-fix → develop, then merge develop → docs (or manually copy the files into `docs` and push). The deploy workflow will run after `docs` receives a push.

## Checklist (before/after merge)

- [ ] Confirm `docs/index.html` and `docs/index_ar.html` display correctly in the branch preview.
- [ ] Ensure Actions run and `peaceiris/actions-gh-pages` publishes to `gh-pages` without errors.
- [ ] Confirm Settings → Pages is configured to serve from `gh-pages` (root).
- [ ] Validate site at `https://sendipad.github.io/uph/`.

## Notes & follow-ups

- The workflow currently triggers on pushes to the `docs` branch (explicit per request). If you prefer publish-on-merge-to-`develop` or another branch, update `on.push.branches` in `.github/workflows/deploy-pages.yml`.
- If you want automatic Markdown → HTML conversion (so you can edit `.md` and get HTML generated during CI), we can add a build step (MkDocs / pandoc) to the workflow; currently this PR commits HTML directly to keep the workflow simple.
- I can add a small shared stylesheet, language switcher, or SEO tags in a follow-up PR.

If you want, add these reviewers: @Sendipad (owner), and any team members you'd like to review.
```