### PR TITLE
Switch site config to Doks theme and update docs URLs under /uph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unified Party Hub Docs
 
-This repository uses Hugo (Book theme). A MkDocs scaffold also exists, but Hugo is the primary production generator.
+This repository uses Hugo (Doks theme). A MkDocs scaffold also exists, but Hugo is the primary production generator.
 
 ## Why pages may not open
 

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
 
 baseURL = "https://sendipad.github.io/uph/"
 title = "Unified Party Hub"
-theme = "book"
+theme = "doks"
 languageCode = "en-us"
 disablePathToLower = true
 enableGitInfo = true

--- a/content.en/_index.md
+++ b/content.en/_index.md
@@ -60,7 +60,7 @@ A Frappe/ERPNext extension for **centralized Party Master identity**, role-aware
 [{{< badge style="info" title="Version" value="1.0" >}}](https://github.com/Sendipad/uph/releases)
 [{{< badge style="default" title="License" value="MIT" >}}](https://github.com/Sendipad/uph/blob/main/LICENSE)
 
-{{< button href="/en/docs/" >}}Read Technical Docs{{< /button >}}
+{{< button href="/uph/en/docs/" >}}Read Technical Docs{{< /button >}}
 
   <section>
     <h2>Architecture & Modules</h2>
@@ -121,7 +121,7 @@ Then configure **Party Master Settings** to map target doctypes and party types.
 
 ## API Reference
 
-See [API Reference](/en/docs/api/) for whitelisted/search/report function entry points extracted from current implementation.
+See [API Reference](/uph/en/docs/api/) for whitelisted/search/report function entry points extracted from current implementation.
 
 ---
 

--- a/content.en/docs/_index.md
+++ b/content.en/docs/_index.md
@@ -18,8 +18,8 @@ This documentation is generated from the **current branch implementation**. Beca
 
 ## Sections
 
-- [Introduction](/en/docs/introduction/)
-- [Architecture](/en/docs/architecture/)
-- [Modules](/en/docs/modules/)
-- [API Reference](/en/docs/api/)
-- [Operations](/en/docs/operations/)
+- [Introduction](/uph/en/docs/introduction/)
+- [Architecture](/uph/en/docs/architecture/)
+- [Modules](/uph/en/docs/modules/)
+- [API Reference](/uph/en/docs/api/)
+- [Operations](/uph/en/docs/operations/)

--- a/content.en/docs/api/_index.md
+++ b/content.en/docs/api/_index.md
@@ -8,4 +8,4 @@ bookCollapseSection: true
 Technical details for all whitelisted API endpoints in the UPH application.
 
 
-See also: [Verification Status (Current Branch vs Legacy API Docs)](/en/docs/api/verification-status/).
+See also: [Verification Status (Current Branch vs Legacy API Docs)](/uph/en/docs/api/verification-status/).


### PR DESCRIPTION
### Motivation
- Replace the current Hugo Book theme with GetDoks (Doks) as requested so the site uses the Doks static site look-and-feel.
- Ensure all internal docs links point to the repository subpath so published pages resolve under `https://sendipad.github.io/uph/` (i.e. links should start with `/uph/en/docs/`).

### Description
- Updated the site configuration in `config.toml` to set `theme = "doks"` so the site is configured to use Doks.
- Updated `README.md` to reference the Doks theme instead of Book.
- Rewrote internal documentation links in `content.en/_index.md`, `content.en/docs/_index.md`, and `content.en/docs/api/_index.md` to use `/uph/en/docs/...` instead of `/en/docs/...`.
- Attempted to vendor the Doks theme into `themes/doks`, but fetching the upstream theme failed due to network restrictions; the repo-level theme files will need to be installed where network access is available.

### Testing
- Verified replacements by running a search for the old path pattern and confirmed occurrences of `/en/docs/` were updated to `/uph/en/docs/` using `rg` (success).
- Attempted `hugo --minify` to build the site, but `hugo` is not installed in the environment so the build could not be run (failed).
- Attempted to `git clone` the Doks theme into `themes/doks`, but the network request failed with `CONNECT tunnel failed, response 403` (failed).
- Tried a Playwright snapshot of a local preview server, but no Hugo server was running/available so the check returned `ERR_EMPTY_RESPONSE` (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0aaa3284832ba852324120b033a5)