### PR TITLE
Switch to bundled Book theme and unblank Hugo home pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
 
 baseURL = "https://sendipad.github.io/uph/"
 title = "Unified Party Hub"
-theme = "github.com/h-enk/doks"
+theme = "book"
 languageCode = "en-us"
 disablePathToLower = true
 enableGitInfo = true

--- a/content.ar/_index.md
+++ b/content.ar/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "مركز الأطراف الموحد"
-layout: landing
 ---
 
 <div class="book-hero">

--- a/content.en/_index.md
+++ b/content.en/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Unified Party Hub"
-layout: landing
 ---
 
 <div class="uph-landing">


### PR DESCRIPTION
### Motivation
- Remove dependency on a remote Doks theme and use the bundled `book` theme so the site can render with local templates.
- Fix blank home pages caused by the `landing` layout which only defines header/menu container blocks and produces no main content when used as a page layout.

### Description
- Updated `config.toml` to set `theme = "book"` so Hugo uses the local `themes/book` theme.
- Removed `layout: landing` from `content.en/_index.md` and `content.ar/_index.md` so the home pages render via the normal home/index templates instead of the incomplete `landing` layout.
- Verified the `themes/book` layout structure and adjusted front matter to avoid resolving to the empty `landing` template.

### Testing
- Verified file changes with `git diff` and inspected files with `nl`/`sed`; those checks succeeded and show the theme/front-matter updates.
- Attempted to run `hugo version` but `hugo` is not installed in the environment so the binary check failed.
- Attempted to install or download Hugo (`apt-get` and `curl`) but network/proxy returned HTTP 403 so the runtime build/download could not be completed.
- Attempted a Playwright navigation/screenshot against a local preview server and received `ERR_EMPTY_RESPONSE` because no local Hugo server was running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d17378e80832b89c57a39ebbbea6f)