### PR TITLE
Fix landing icons, add landing styles, and use bundled Book theme

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
 
 baseURL = "https://sendipad.github.io/uph/"
 title = "Unified Party Hub"
-theme = "github.com/h-enk/doks"
+theme = "book"
 languageCode = "en-us"
 disablePathToLower = true
 enableGitInfo = true

--- a/content.ar/_index.md
+++ b/content.ar/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "مركز الأطراف الموحد"
-layout: landing
 ---
 
 <div class="book-hero">

--- a/content.ar/_index.md
+++ b/content.ar/_index.md
@@ -12,7 +12,7 @@ title: "مركز الأطراف الموحد"
 [{{< badge style="info" title="الإصدار" value="1.0" >}}](https://github.com/sendipad/uph/releases)
 [{{< badge style="default" title="الترخيص" value="MIT" >}}](https://github.com/sendipad/uph/blob/main/LICENSE)
 
-{{< button href="/ar/docs/introduction/" >}}ابدأ الآن{{< /button >}}
+{{< button href="/uph/ar/docs/introduction/" >}}ابدأ الآن{{< /button >}}
 
 </div>
 

--- a/content.en/_index.md
+++ b/content.en/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Unified Party Hub"
-layout: landing
 ---
 
 <div class="uph-landing">

--- a/layouts/partials/docs/menu-hugo.html
+++ b/layouts/partials/docs/menu-hugo.html
@@ -1,0 +1,50 @@
+<!--
+  Local override of book/docs/menu-hugo.
+  Ensures internal menu links respect baseURL subpaths (e.g. /uph/) via relLangURL.
+-->
+{{- if .Menu -}}
+  {{- template "book-menu-hugo" . -}}
+{{- end -}}
+
+{{ define "book-menu-hugo" }}
+<ul>
+{{- range .Menu -}}
+  {{- $class := slice -}}
+  {{- with .Params.class -}}
+    {{- $class = $class | append . -}}
+  {{- end -}}
+  {{- if $.Page.IsMenuCurrent .Menu . -}}
+    {{- $class = $class | append "active" -}}
+  {{- end -}}
+  <li>
+    {{- $isRemote := (urls.Parse .URL).IsAbs -}}
+    {{- $href := .URL -}}
+    {{- if and (not $isRemote) (hasPrefix .URL "/") -}}
+      {{- $href = .URL | relLangURL -}}
+    {{- end -}}
+    <a href="{{ $href }}"
+      {{- with $class }} class="{{ delimit . " " }}"{{- end -}}
+      {{- with .Title }} title="{{ . }}"{{- end -}}
+      {{- if $isRemote }} target="_blank" rel="noopener"{{- end -}}>
+      {{- .Pre -}}
+      {{- template "book-menu-title" . -}}
+      {{- .Post -}}
+    </a>
+    {{- with .Children -}}
+      {{- template "book-menu-hugo" (dict "Page" $.Page "Menu" .) -}}
+    {{- end -}}
+  </li>
+{{- end -}}
+</ul>
+{{ end }}
+
+{{ define "book-menu-title" }}
+{{- with .Params.BookIcon -}}
+  <img src="{{ partial "docs/icon" . }}" class="book-icon" alt="{{ partial "docs/text/i18n" . }}" />
+{{- end -}}
+{{- if .Name -}}
+  {{- .Name -}}
+{{- else if .Page -}}
+  {{- partial "docs/title" .Page -}}
+{{- end -}}
+{{ end }}

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -66,3 +66,64 @@
     color: #e2e8f0;
   }
 }
+
+/* Enhanced landing page styles for layouts/index.html */
+.hero,
+.section {
+  position: relative;
+}
+
+.hero-content.container,
+.section .container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.features-grid,
+.doctypes-grid,
+.usecases-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-card,
+.doctype-card,
+.usecase-card {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 1rem;
+  background: linear-gradient(180deg, rgba(255,255,255,0.95), rgba(248,250,252,0.95));
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
+}
+
+.feature-icon,
+.doctype-icon,
+.usecase-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #2563eb;
+  margin-bottom: 0.5rem;
+}
+
+.feature-icon svg,
+.doctype-icon svg,
+.usecase-icon svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  max-width: 1.5rem;
+  max-height: 1.5rem;
+  display: block;
+}
+
+@media (prefers-color-scheme: dark) {
+  .feature-card,
+  .doctype-card,
+  .usecase-card {
+    background: linear-gradient(180deg, rgba(30,41,59,0.88), rgba(15,23,42,0.88));
+    color: #e2e8f0;
+  }
+}


### PR DESCRIPTION
### Motivation
- Preserve the site base path at `https://sendipad.github.io/uph/` and avoid root-domain routing surprises. 
- Prevent oversized SVG icons on the landing/home page which made feature/doctype/usecase icons render very large. 
- Use the bundled `book` theme so the site renders with local templates instead of a remote theme.

### Description
- Ensured `baseURL` remains `https://sendipad.github.io/uph/` and switched the theme to the local `book` theme by updating `config.toml`.
- Removed `layout: landing` from `content.en/_index.md` and `content.ar/_index.md` so the home pages render with the normal home/index templates.
- Added explicit landing-page styles in `static/css/landing.css` that introduce grid/card layout rules and constrain icon wrapper sizes and nested SVG dimensions for `.feature-icon`, `.doctype-icon`, and `.usecase-icon`.
- Committed the changes as `Tighten landing icon sizing and preserve /uph base URL config` (HEAD: `d8e9ca7`).

### Testing
- Verified configuration and edits with `rg` and `sed`/`nl` to confirm `baseURL` and new CSS selectors were added (succeeded).
- Inspected the `git diff` and committed with `git commit` to record the change (succeeded).
- Attempted a Playwright navigation/screenshot against a local Hugo preview at `http://127.0.0.1:1313/en/`, but the local Hugo server did not respond (`ERR_EMPTY_RESPONSE`), so visual validation could not be captured (failed).
- Attempted `git pull --ff-only docs docs` to sync the remote docs branch, but the remote `docs` repository is not configured in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d17378e80832b89c57a39ebbbea6f)