### PR TITLE
fix(party): Transaction Health incorrect false positives on amended docs

### DIFF
--- a/uph/party/controllers/transaction_health.py
+++ b/uph/party/controllers/transaction_health.py
@@ -392,18 +392,22 @@ def run_transaction_policy_scan():
             start += page_len
 
         # Cancelled voucher not amended
-        # For child records, we must check 'amended_from' on the PARENT
-        has_amended_from = False
+        # NOTE: In Frappe, amended_from is set on the NEW amended doc,
+        # NOT on the original cancelled one. So we must check whether
+        # any other doc has amended_from pointing to the cancelled doc's name.
+        has_amended_from_field = False
         if is_child:
-            has_amended_from = frappe.get_meta(parent_dt).has_field("amended_from")
+            has_amended_from_field = frappe.get_meta(parent_dt).has_field(
+                "amended_from"
+            )
         else:
-            has_amended_from = meta.has_field("amended_from")
+            has_amended_from_field = meta.has_field("amended_from")
 
-        if has_amended_from:
+        if has_amended_from_field:
             if is_child:
                 # Subquery/Join logic for child tables
-                # We want cancelled vouchers (docstatus=2) where parent's amended_from is null
-                # We use frappe.get_all but we need to fetch 'parent' to check against amended parents
+                # We want cancelled vouchers (docstatus=2) where NO other
+                # parent doc has amended_from pointing to this parent.
                 filters = [
                     ["docstatus", "=", 2],
                     ["party_master", "is", "set"],
@@ -419,13 +423,16 @@ def run_transaction_policy_scan():
 
                 if cancelled:
                     parent_names = list(set(r.parent for r in cancelled))
-                    amended_parents = frappe.get_all(
-                        parent_dt,
-                        filters={
-                            "name": ["in", parent_names],
-                            "amended_from": ["is", "set"],
-                        },
-                        pluck="name",
+                    # Find parents that HAVE BEEN amended:
+                    # i.e. another doc exists with amended_from = parent_name
+                    amended_parents = set(
+                        frappe.get_all(
+                            parent_dt,
+                            filters={
+                                "amended_from": ["in", parent_names],
+                            },
+                            pluck="amended_from",
+                        )
                     )
 
                     for r in cancelled:
@@ -446,7 +453,6 @@ def run_transaction_policy_scan():
                 filters = {
                     "docstatus": 2,
                     "party_master": ["is", "set"],
-                    "amended_from": ["in", [None, ""]],
                 }
                 if cutoff_cancelled:
                     filters["modified"] = ["<=", cutoff_cancelled]
@@ -464,7 +470,21 @@ def run_transaction_policy_scan():
                     if not cancelled:
                         break
 
+                    # Find which cancelled doc names have been amended:
+                    # i.e. another doc exists with amended_from = cancelled_name
+                    cancelled_names = [r.name for r in cancelled]
+                    amended_names = set(
+                        frappe.get_all(
+                            dt,
+                            filters={"amended_from": ["in", cancelled_names]},
+                            pluck="amended_from",
+                        )
+                    )
+
                     for row in cancelled:
+                        if row.name in amended_names:
+                            continue
+
                         create_party_issue_if_missing(
                             party_master=row.party_master,
                             issue_type="Transaction Policy",
@@ -590,11 +610,11 @@ def sync_transaction_health_issues():
             if doc.docstatus != 0:
                 is_resolved = True
         elif code == "cancelled_referenced":
-            has_amended_from = False
-            if hasattr(doc, "amended_from") and doc.amended_from:
-                has_amended_from = True
+            # In Frappe, amended_from is on the NEW doc, not the cancelled one.
+            # Check if any other doc has amended_from pointing to this doc.
+            has_been_amended = bool(frappe.db.exists(dt, {"amended_from": dn}))
 
-            if doc.docstatus != 2 or has_amended_from:
+            if doc.docstatus != 2 or has_been_amended:
                 is_resolved = True
         elif code == "party_master_mismatch":
             # For mismatch, we need to re-verify the expected party_master
@@ -680,8 +700,17 @@ def get_health_counts():
 
         if has_amended_from:
             table = frappe.qb.DocType(dt)
+            # In Frappe, amended_from is on the NEW doc, not the cancelled one.
+            # Use a NOT IN subquery to exclude cancelled docs that have been amended.
             if is_child:
                 parent_table = frappe.qb.DocType(parent_dt)
+                # Subquery: parent names that are referenced by amended_from
+                amended_sq = (
+                    frappe.qb.from_(parent_table)
+                    .select(parent_table.amended_from)
+                    .where(parent_table.amended_from.isnotnull())
+                    .where(parent_table.amended_from != "")
+                )
                 result = (
                     frappe.qb.from_(table)
                     .join(parent_table)
@@ -691,14 +720,19 @@ def get_health_counts():
                         (table.docstatus == 2)
                         & (table.party_master.isnotnull())
                         & (table.party_master != "")
-                        & (
-                            (parent_table.amended_from.isnull())
-                            | (parent_table.amended_from == "")
-                        )
+                        & (parent_table.name.notin(amended_sq))
                     )
                     .run(as_dict=True)
                 )
             else:
+                # Subquery: doc names that are referenced by another doc's amended_from
+                table2 = frappe.qb.DocType(dt)
+                amended_sq = (
+                    frappe.qb.from_(table2)
+                    .select(table2.amended_from)
+                    .where(table2.amended_from.isnotnull())
+                    .where(table2.amended_from != "")
+                )
                 result = (
                     frappe.qb.from_(table)
                     .select(frappe.query_builder.functions.Count("*").as_("cnt"))
@@ -706,7 +740,7 @@ def get_health_counts():
                         (table.docstatus == 2)
                         & (table.party_master.isnotnull())
                         & (table.party_master != "")
-                        & ((table.amended_from.isnull()) | (table.amended_from == ""))
+                        & (table.name.notin(amended_sq))
                     )
                     .run(as_dict=True)
                 )

--- a/uph/tests/test_transaction_health.py
+++ b/uph/tests/test_transaction_health.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, Abdo Ruzaqi and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from uph.party.controllers.transaction_health import (
+    sync_transaction_health_issues,
+    get_health_counts,
+)
+
+
+class TestTransactionHealth(FrappeTestCase):
+    def setUp(self):
+        # Create a parent party master group
+        self.parent = frappe.get_doc(
+            {
+                "doctype": "Party Master",
+                "party_name": f"Test Parent Group {frappe.generate_hash(length=8)}",
+                "is_group": 1,
+            }
+        ).insert(ignore_permissions=True)
+
+        # Create a party master
+        self.party = frappe.get_doc(
+            {
+                "doctype": "Party Master",
+                "party_name": f"Test Health {frappe.generate_hash(length=8)}",
+                "party_type": "Customer",
+                "parent_party_master": self.parent.name,
+                "is_group": 0,
+            }
+        ).insert(ignore_permissions=True)
+        self.party.db_set("status", "Active")
+
+        # Create a custom customer for this test and link to the party master
+        self.customer = frappe.get_doc(
+            {
+                "doctype": "Customer",
+                "customer_name": f"Test Customer {frappe.generate_hash(length=8)}",
+                "customer_group": frappe.get_all("Customer Group", limit=1)[0].name,
+                "territory": frappe.get_all("Territory", limit=1)[0].name,
+                "party_master": self.party.name,
+            }
+        ).insert(ignore_permissions=True)
+
+        frappe.db.commit()
+
+    def tearDown(self):
+        frappe.db.rollback()
+
+    def test_cancelled_amended_logic(self):
+        # Create an original invoice
+        si1 = frappe.get_doc(
+            {
+                "doctype": "Sales Invoice",
+                "customer": self.customer.name,
+                "party_master": self.party.name,
+                "docstatus": 1,
+                "items": [
+                    {
+                        "item_code": frappe.get_all("Item", limit=1)[0].name,
+                        "qty": 1,
+                        "rate": 100,
+                    }
+                ],
+                "set_posting_time": 1,
+            }
+        ).insert(ignore_permissions=True)
+        si1.reload()
+        si1.submit()
+
+        # Cancel the original invoice
+        si1.cancel()
+
+        # At this point, it's canceled and unamended
+        frappe.cache.delete_value("uph:health_counts")
+        counts_before = get_health_counts()
+        self.assertGreaterEqual(counts_before["cancelled_unamended_count"], 1)
+
+        # Create a party issue for it
+        issue = frappe.get_doc(
+            {
+                "doctype": "Party Issue",
+                "party_master": self.party.name,
+                "issue_type": "Transaction Policy",
+                "reference_doctype": "Sales Invoice",
+                "reference_name": si1.name,
+                "severity": "High",
+                "status": "Open",
+                "source_engine": "test",
+                "details_json": '{"issue": "cancelled_referenced"}',
+            }
+        ).insert(ignore_permissions=True)
+
+        # Create an amended invoice
+        si2 = frappe.copy_doc(si1)
+        si2.docstatus = 0
+        si2.amended_from = si1.name
+        si2.insert(ignore_permissions=True)
+        si2.reload()
+        si2.submit()
+
+        # The new logic should now see that si1 was amended
+        frappe.cache.delete_value("uph:health_counts")
+        counts_after = get_health_counts()
+        self.assertLess(
+            counts_after["cancelled_unamended_count"],
+            counts_before["cancelled_unamended_count"],
+        )
+
+        # Sync should auto-resolve the issue
+        sync_transaction_health_issues()
+        issue.reload()
+        self.assertEqual(issue.status, "Resolved")


### PR DESCRIPTION

The code formerly checked the \`amended_from\` field on the canceled document itself, which is always empty. This fix refactors the logic to check if *another* document has an \`amended_from\` pointing to the canceled document's name, accurately aligning with standard Frappe tracking behavior.

### Changes:
* Refactored scan queries for both standard and child doctypes in \`run_transaction_policy_scan\`
* Updated resolving logic inside \`sync_transaction_health_issues\`
* Fixed tally in \`get_health_counts\`
* Created robust unit test coverage in \`test_transaction_health.py\`"