### PR TITLE
fix: resolve migration implicit commit and voucher linking sync bugs

### DIFF
--- a/uph/party/controllers/party.py
+++ b/uph/party/controllers/party.py
@@ -394,15 +394,22 @@ def on_change_party_master_update_transactional_document_types(
     if changes:
         content = ", ".join(changes)
 
-        party.add_comment(
-            "Comment", f"🎯 {content} Assigned to → {party_master or 'NULL'}"
-        )
-
-        if party_master:
-            doc_pm = frappe.get_doc("Party Master", party_master)
-            doc_pm.add_comment(
-                "Comment", f"{party.name} Assigned and Updated: {content}"
+        try:
+            party.add_comment(
+                "Comment", f"🎯 {content} Assigned to → {party_master or 'NULL'}"
             )
+
+            if party_master:
+                doc_pm = frappe.get_doc("Party Master", party_master)
+                doc_pm.add_comment(
+                    "Comment", f"{party.name} Assigned and Updated: {content}"
+                )
+        except Exception as e:
+            # Prevent QueryDeadlockError or other comment insertion failures from breaking the voucher sync loop
+            frappe.logger("uph").warning(
+                f"Failed to add comment to {party.name} during voucher sync: {e}"
+            )
+
     if not counts_only:
         frappe.db.commit()
 

--- a/uph/setup/install.py
+++ b/uph/setup/install.py
@@ -249,6 +249,7 @@ def create_custom_indices():
             f"SHOW INDEX FROM `{table}` WHERE Key_name = %s", (index_name,)
         ):
             try:
+                frappe.db.commit()  # Prevent ImplicitCommitError during DDL statement
                 frappe.db.sql(
                     f"CREATE INDEX `{index_name}` ON `{table}` ({', '.join(columns)})"
                 )


### PR DESCRIPTION
This PR fixes a bug where transactional vouchers were not automatically updated when linking unlinked roles to a Party Master from the Data Quality Dashboard. It also resolves a QueryDeadlockError during massive background updates, an ImplicitCommitError during migration, and clears out old uph.hub scheduled jobs. Version bumped to 3.3.0.