### PR TITLE
fix: refine unlinked voucher logic

### DIFF
--- a/uph/party/controllers/transaction_health.py
+++ b/uph/party/controllers/transaction_health.py
@@ -74,7 +74,14 @@ def get_transaction_health(
             SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(pi.details_json, '$.issue')) = 'draft_overdue' THEN 1 ELSE 0 END) AS draft_count,
             SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(pi.details_json, '$.issue')) = 'cancelled_referenced' THEN 1 ELSE 0 END) AS cancelled_unamended_count,
             SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(pi.details_json, '$.issue')) = 'party_master_mismatch' THEN 1 ELSE 0 END) AS mismatch_count,
-            COUNT(*) AS total_issues
+            COUNT(*) AS total_issues,
+            MIN(CASE severity
+                WHEN 'Critical' THEN 0
+                WHEN 'High' THEN 1
+                WHEN 'Medium' THEN 2
+                WHEN 'Low' THEN 3
+                ELSE 4
+            END) AS severity_rank
         FROM `tabParty Issue` pi
         WHERE pi.issue_type = 'Transaction Policy'
           AND pi.status IN ('Open', 'Under Review')
@@ -106,12 +113,15 @@ def get_transaction_health(
         ref_dt = row.reference_doctype or ""
         total = cint(row.total_issues)
 
-        # Per-doctype severity: if warn_not_submitted_document is checked
-        # for this doctype, severity is always High
-        if ref_dt in warn_doctypes:
+        # Per-doctype severity: if warn_not_submitted_document is enabled
+        # for this doctype, severity is at least High
+        severity_map_rev = {0: "Critical", 1: "High", 2: "Medium", 3: "Low", 4: "Low"}
+        base_severity = severity_map_rev.get(row.severity_rank, "Low")
+
+        if ref_dt in warn_doctypes and row.severity_rank > 1:
             severity = "High"
         else:
-            severity = "High" if total >= 10 else ("Medium" if total >= 3 else "Low")
+            severity = base_severity
 
         results.append(
             {
@@ -127,8 +137,8 @@ def get_transaction_health(
             }
         )
 
-    # Sort: High severity first, then by reference_doctype, then total_issues desc
-    severity_order = {"High": 0, "Medium": 1, "Low": 2}
+    # Sort: Critical -> High -> Medium -> Low, then by reference_doctype, then total_issues desc
+    severity_order = {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}
     results.sort(
         key=lambda x: (
             severity_order.get(x["severity"], 9),

--- a/uph/party/controllers/unlinked_resolver.py
+++ b/uph/party/controllers/unlinked_resolver.py
@@ -152,8 +152,36 @@ def get_unlinked_transactions(
         if not meta.has_field("party_master"):
             continue
 
+        # Build the WHERE clause and count filters
+        from uph.party.controllers.cache_utils import (
+            get_doctypes_functional_fields_mapping_as_dict,
+        )
+
+        mappings = get_doctypes_functional_fields_mapping_as_dict()
+        map_conf = mappings.get(dt, {})
+        party_fieldname = map_conf.get("party_fieldname")
+        parent_dt = map_conf.get("parent_doctype") or dt
+
+        extra_where = ""
+        if party_fieldname:
+            extra_where = (
+                f" AND (`{party_fieldname}` IS NOT NULL AND `{party_fieldname}` != '')"
+            )
+
+        # Exclude Internal Transfer Payment Entries
+        if dt == "Payment Entry" or parent_dt == "Payment Entry":
+            extra_where += " AND `payment_type` != 'Internal Transfer'"
+
+        where_clause = f"(party_master IS NULL OR party_master = ''){extra_where}"
+
         # Count
-        total += frappe.db.count(dt, {"party_master": ["in", [None, ""]]})
+        count_filters = {"party_master": ["in", [None, ""]]}
+        if party_fieldname:
+            count_filters[party_fieldname] = ["is", "set"]
+        if dt == "Payment Entry" or parent_dt == "Payment Entry":
+            count_filters["payment_type"] = ["!=", "Internal Transfer"]
+
+        total += frappe.db.count(dt, count_filters)
 
         is_child = meta.istable
 
@@ -168,7 +196,7 @@ def get_unlinked_transactions(
                     '' AS owner,
                     `creation` AS creation
                 FROM `tab{dt}`
-                WHERE (party_master IS NULL OR party_master = '')
+                WHERE {where_clause}
             """
             )
         else:
@@ -185,7 +213,7 @@ def get_unlinked_transactions(
                     {owner_expr} AS owner,
                     `creation` AS creation
                 FROM `tab{dt}`
-                WHERE (party_master IS NULL OR party_master = '')
+                WHERE {where_clause}
             """
             )
 
@@ -862,7 +890,23 @@ def get_unlinked_transaction_count():
         if not meta.has_field("party_master"):
             continue
 
-        total += frappe.db.count(dt, {"party_master": ["in", [None, ""]]})
+        from uph.party.controllers.cache_utils import (
+            get_doctypes_functional_fields_mapping_as_dict,
+        )
+
+        mappings = get_doctypes_functional_fields_mapping_as_dict()
+        map_conf = mappings.get(dt, {})
+        party_fieldname = map_conf.get("party_fieldname")
+        parent_dt = map_conf.get("parent_doctype") or dt
+
+        filters = {"party_master": ["in", [None, ""]]}
+        if party_fieldname:
+            filters[party_fieldname] = ["is", "set"]
+
+        if dt == "Payment Entry" or parent_dt == "Payment Entry":
+            filters["payment_type"] = ["!=", "Internal Transfer"]
+
+        total += frappe.db.count(dt, filters)
 
     frappe.cache.set_value(cache_key, total, expires_in_sec=300)
     return total

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
@@ -893,7 +893,7 @@ class DataQualityDashboard {
         `);
 
         data.parties.forEach(p => {
-            const severity_color = p.severity === 'High' ? 'var(--red-500)' : (p.severity === 'Medium' ? 'var(--orange-500)' : 'var(--yellow-600)');
+            const severity_color = p.severity === 'Critical' ? 'var(--red-700)' : (p.severity === 'High' ? 'var(--red-500)' : (p.severity === 'Medium' ? 'var(--orange-500)' : 'var(--yellow-600)'));
             const row = $(`
                 <div class="health-row" style="display: flex; align-items: center; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border-color); background: var(--card-bg);">
                     <div style="flex: 2;">

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.py
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.py
@@ -5,6 +5,9 @@ import frappe
 from frappe import _
 from frappe.utils import cint
 import json
+from uph.party.controllers.cache_utils import (
+    get_doctypes_functional_fields_mapping_as_dict,
+)
 
 
 @frappe.whitelist()
@@ -186,11 +189,38 @@ def get_unlinked_voucher_issues(
             continue
 
         # Build the WHERE clause and count filters
-        where_clause = "(party_master IS NULL OR party_master = '')"
+        # Only consider rows that actually have a party set in the designated field
+        party_fieldname = dt_info.get("party_fieldname")
+        if not party_fieldname:
+            mappings = get_doctypes_functional_fields_mapping_as_dict()
+            party_fieldname = mappings.get(dt, {}).get("party_fieldname")
+
+        extra_where = ""
+        if party_fieldname:
+            extra_where = (
+                f" AND (`{party_fieldname}` IS NOT NULL AND `{party_fieldname}` != '')"
+            )
+
+        # Exclude Internal Transfer Payment Entries
+        if dt == "Payment Entry" or parent_dt == "Payment Entry":
+            extra_where += " AND `payment_type` != 'Internal Transfer'"
+
+        where_clause = f"(party_master IS NULL OR party_master = ''){extra_where}"
+
+        # Build count filters for frappe.db.count
         count_filters = {"party_master": ["in", [None, ""]]}
+        if party_fieldname:
+            count_filters[party_fieldname] = ["is", "set"]
+        if dt == "Payment Entry" or parent_dt == "Payment Entry":
+            count_filters["payment_type"] = ["!=", "Internal Transfer"]
+
         if party_master:
-            where_clause = "party_master = %(party_master)s"
+            where_clause = f"party_master = %(party_master)s{extra_where}"
             count_filters = {"party_master": party_master}
+            if party_fieldname:
+                count_filters[party_fieldname] = ["is", "set"]
+            if dt == "Payment Entry" or parent_dt == "Payment Entry":
+                count_filters["payment_type"] = ["!=", "Internal Transfer"]
 
         # Count
         total += frappe.db.count(dt, count_filters)


### PR DESCRIPTION
Refined the logic for identifying unlinked vouchers in the Data Quality Dashboard.

Key changes:
- Only consider rows that have a value in their designated party field.
- Exclude Internal Transfer Payment Entries from unlinked voucher checks.
- Applied consistent logic to unlinked transaction counts.

Verified on insight.test with custom and existing tests.