### PR TITLE
Normalize vouchers on first-time Party Master linking

### DIFF
--- a/uph/party/controllers/party.py
+++ b/uph/party/controllers/party.py
@@ -442,8 +442,8 @@ def _update_party_master_field_on_exists_transactional_document_types(
     if old_party_master:
         conditions &= doc.party_master == old_party_master
     else:
-        # Match documents where party_master is NULL or empty, and different from target
-        conditions &= Coalesce(doc.party_master, "") == ""
+        # First-time linking should normalize all existing vouchers for this party.
+        # We only skip documents already pointing to the target Party Master.
         conditions &= Coalesce(doc.party_master, "") != (party_master or "")
 
     # Avoid touching cancelled documents for audit integrity

--- a/uph/tests/test_party_controllers.py
+++ b/uph/tests/test_party_controllers.py
@@ -188,6 +188,66 @@ class TestPartyControllers(FrappeTestCase, AccountsTestMixin):
         updated_si_pm = frappe.db.get_value("Sales Invoice", si_name, "party_master")
         self.assertEqual(updated_si_pm, new_pm_name)
 
+    def test_first_link_updates_vouchers_with_incorrect_party_master(self):
+        from uph.party.controllers.party import (
+            on_change_party_master_update_transactional_document_types,
+        )
+
+        # Create a secondary PM to simulate stale/wrong voucher data
+        existing_pm = frappe.get_doc("Party Master", self.party_master)
+        parent_group = existing_pm.parent_party_master
+
+        stale_pm = frappe.get_doc(
+            {
+                "doctype": "Party Master",
+                "party_name": f"_Test Stale PM {frappe.generate_hash(length=6)}",
+                "parent_party_master": parent_group,
+                "is_group": 0,
+                "party_type": "Customer",
+                "type": "Individual",
+            }
+        )
+        stale_pm.party_number = _unique_party_number()
+        stale_pm.insert(ignore_permissions=True)
+
+        # Start with an unlinked customer (old_party_master = None)
+        customer_doc = frappe.get_doc("Customer", self.customer)
+        customer_doc.party_master = None
+        customer_doc.save(ignore_permissions=True)
+
+        # Existing voucher has stale Party Master and should be normalized on first link
+        si = frappe.new_doc("Sales Invoice")
+        si.company = self.company
+        si.customer = self.customer
+        si.party_master = stale_pm.name
+        si.debit_to = self.debit_to
+        si.currency = self.currency
+        si.posting_date = frappe.utils.today()
+        si.due_date = frappe.utils.today()
+        si.conversion_rate = 1
+        si.plc_conversion_rate = 1
+        si.append(
+            "items",
+            {
+                "item_code": "_Test Item",
+                "qty": 1,
+                "rate": 100,
+                "income_account": self.income_account,
+                "cost_center": self.cost_center,
+            },
+        )
+        si.insert()
+
+        # First link to Party Master
+        customer_doc = frappe.get_doc("Customer", self.customer)
+        customer_doc.party_master = self.party_master
+        on_change_party_master_update_transactional_document_types(
+            party=customer_doc, old_party_master=None, counts_only=False
+        )
+
+        updated_si_pm = frappe.db.get_value("Sales Invoice", si.name, "party_master")
+        self.assertEqual(updated_si_pm, self.party_master)
+
     def test_check_duplicate_voucher_party_master(self):
         from uph.party.controllers.party import check_duplicate_voucher_party_master
 


### PR DESCRIPTION
### Motivation
- Fix a bug where vouchers that already had a non-empty (but incorrect) `party_master` value were not updated when a party was linked to a Party Master for the first time. 
- Ensure transactional documents configured in `Party Master Settings` are normalized to the newly linked Party Master when a party moves from unlinked to linked state.

### Description
- Change the filter in `_update_party_master_field_on_exists_transactional_document_types` so that when `old_party_master` is `None` we update all vouchers for the party except those already pointing to the target `party_master` by replacing the empty-only check with `Coalesce(doc.party_master, "") != (party_master or "")` in `uph/party/controllers/party.py`.
- Add a regression test `test_first_link_updates_vouchers_with_incorrect_party_master` that creates a stale Party Master on an existing voucher, links the party for the first time, calls `on_change_party_master_update_transactional_document_types`, and asserts the voucher `party_master` is normalized in `uph/tests/test_party_controllers.py`.
- Kept the bulk-update path using the same QB `update(...).where(conditions)` flow so the change is limited to selection logic only.

### Testing
- Ran `python -m compileall uph/party/controllers/party.py uph/tests/test_party_controllers.py` which succeeded and confirmed the patched files are syntactically valid. 
- Attempted `pytest -q uph/tests/test_party_controllers.py -k first_link_updates_vouchers_with_incorrect_party_master` in this environment but test collection failed with `ModuleNotFoundError: No module named 'frappe'`, so the unit test could not be executed here. 
- The new test exercises the `on_change_party_master_update_transactional_document_types` path with `counts_only=False` and should validate the fix in an environment where `frappe`/ERPNext is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4dffb8478832bae773b9a84afd9d7)