### PR TITLE
docs: label clone badge as 14-day total

### DIFF
--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -24,18 +24,19 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/Sendipad/uph/traffic/clones \
-            -o clones.json
+            -o traffic.json
 
       - name: Extract total count
         run: |
-          COUNT=$(jq '.count' clones.json)
-          echo "{ \"count\": $COUNT }" > clones.json
+          COUNT=$(jq '.count' traffic.json)
+          mkdir -p stats
+          echo "{ \"count\": $COUNT }" > stats/clones.json
 
       - name: Commit and push to stats branch
         run: |
           git checkout -B stats
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
-          git add clones.json
+          git add stats/clones.json
           git commit -m "Update clone stats" || exit 0
           git push origin stats --force

--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -29,14 +29,13 @@ jobs:
       - name: Extract total count
         run: |
           COUNT=$(jq '.count' traffic.json)
-          mkdir -p stats
-          echo "{ \"count\": $COUNT }" > stats/clones.json
+          echo "{ \"count\": $COUNT }" > clones.json
 
       - name: Commit and push to stats branch
         run: |
           git checkout -B stats
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
-          git add stats/clones.json
+          git add clones.json
           git commit -m "Update clone stats" || exit 0
           git push origin stats --force

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   <p><b>Centralize. Unify. Govern.</b></p>
 
-![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
+![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/stats/clones.json)
   [![CI develop](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v17&label=CI%20develop)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v16](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v16&label=CI%20v16)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v15](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v15&label=CI%20v15)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
@@ -516,7 +516,6 @@ This project is licensed under the GPL-3.0 License - see the [LICENSE](license.t
   
 
 ---
-![Clones](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/develop/clones.json)
 
 <div align="center">
   <sub>Built with ❤️ for the ERPNext Community</sub>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   <p><b>Centralize. Unify. Govern.</b></p>
 
-![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/stats/clones.json)
+![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
   [![CI develop](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v17&label=CI%20develop)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v16](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v16&label=CI%20v16)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v15](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v15&label=CI%20v15)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   <p><b>Centralize. Unify. Govern.</b></p>
 
-![Clones](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
+![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
   [![CI develop](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v17&label=CI%20develop)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v16](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v16&label=CI%20v16)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v15](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v15&label=CI%20v15)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)


### PR DESCRIPTION
### Motivation
- Make the README badge label explicit so readers know the clone metric reflects the 14-day total from the repository stats file.

### Description
- Updated the badge label in `README.md` to `Clones (14d total)` and retained the same dynamic `count` query sourcing `stats/clones.json`.

### Testing
- Verified the change by running `git diff -- README.md` and `nl -ba README.md | sed -n '1,30p'`, both commands succeeded and show the updated badge text.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a63f190258832b8e6a0c74d52fa312)