### PR TITLE
Persist clone count to stats branch and update README badge

### DIFF
--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -24,18 +24,19 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/Sendipad/uph/traffic/clones \
-            -o clones.json
+            -o traffic.json
 
       - name: Extract total count
         run: |
-          COUNT=$(jq '.count' clones.json)
-          echo "{ \"count\": $COUNT }" > clones.json
+          COUNT=$(jq '.count' traffic.json)
+          mkdir -p stats
+          echo "{ \"count\": $COUNT }" > stats/clones.json
 
       - name: Commit and push to stats branch
         run: |
           git checkout -B stats
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
-          git add clones.json
+          git add stats/clones.json
           git commit -m "Update clone stats" || exit 0
           git push origin stats --force

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   <p><b>Centralize. Unify. Govern.</b></p>
 
-![Clones](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
+![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/stats/clones.json)
   [![CI develop](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v17&label=CI%20develop)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v16](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v16&label=CI%20v16)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v15](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v15&label=CI%20v15)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
@@ -516,7 +516,6 @@ This project is licensed under the GPL-3.0 License - see the [LICENSE](license.t
   
 
 ---
-![Clones](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/develop/clones.json)
 
 <div align="center">
   <sub>Built with ❤️ for the ERPNext Community</sub>

--- a/stats/README.md
+++ b/stats/README.md
@@ -1,0 +1,8 @@
+# Stats Branch Artifacts
+
+This folder is used by the clone-stats GitHub Action.
+
+- On the `stats` branch, the workflow writes `stats/clones.json` every run.
+- The README badge reads that JSON from the `stats` branch.
+
+If you do not see recent data, trigger the **Update Clone Stats** workflow manually and wait for cache refresh.


### PR DESCRIPTION
### Motivation
- Ensure clone statistics are written to a dedicated `stats` folder on the `stats` branch for stable badge consumption. 
- Make the repository README badges point to the persisted artifact on the `stats` branch instead of transient response files. 

### Description
- Updated `.github/workflows/clone-stats.yml` to save the GitHub API response to `traffic.json`, extract the `count`, create a `stats` directory, and write the final JSON to `stats/clones.json` before committing. 
- Adjusted the commit step to `git add stats/clones.json` and push the `stats` branch. 
- Updated `README.md` badges to reference the new raw file path on the `stats` branch (`stats/stats/clones.json`) and removed the old badge that pointed to `develop`. 
- Added `stats/README.md` explaining how the `stats` branch artifacts are produced and where the badge reads the JSON from. 

### Testing
- No automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a63f190258832b8e6a0c74d52fa312)