### PR TITLE
Fix clone stats workflow writing wrong file path

### DIFF
--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Extract total count
         run: |
           COUNT=$(jq '.count' traffic.json)
-          echo "{ \"count\": $COUNT }" > clones.json
+          mkdir -p stats
+          echo "{ \"count\": $COUNT }" > stats/clones.json
 
       - name: Commit and push to stats branch
         run: |


### PR DESCRIPTION
### Motivation
- The scheduled workflow attempted to commit `stats/clones.json` but previously wrote `clones.json` to the repository root, causing `fatal: pathspec 'stats/clones.json' did not match any files`.
- Ensure the workflow writes the artifact to the same path it later stages and pushes so runs no longer fail.

### Description
- Updated `.github/workflows/clone-stats.yml` so the Extract step creates the `stats` directory and writes the JSON to `stats/clones.json` instead of the repo root.
- Added `mkdir -p stats` before writing to guarantee the directory exists.
- No changes outside the workflow file were required.

### Testing
- Ran a local simulation of the Extract step with `echo '{"count": 12}' > traffic.json && COUNT=$(jq '.count' traffic.json) && mkdir -p stats && echo "{ \"count\": $COUNT }" > stats/clones.json && cat stats/clones.json`, which produced the expected JSON payload and file path.
- Verified `git status` and committed the workflow change with `git add .github/workflows/clone-stats.yml && git commit -m "Fix clone stats workflow output path"`, which succeeded.
- Confirmed the workflow file diff contains the `mkdir -p stats` and target `stats/clones.json` updates and that no tests or other CI steps were broken by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a645028278832b8a2e02a55e2be9a1)