### PR TITLE
Improve clone-stats workflow: dynamic repo, branch handling, and robust fetch/parsing

### DIFF
--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -18,22 +18,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Switch to stats branch
+        run: git checkout -B stats
+
       - name: Fetch clone stats from GitHub API
         run: |
-          curl -s \
+          curl -sS \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/Sendipad/uph/traffic/clones \
+            "https://api.github.com/repos/${{ github.repository }}/traffic/clones" \
             -o traffic.json
 
       - name: Extract total count
         run: |
-          COUNT=$(jq '.count' traffic.json)
-          echo "{ \"count\": $COUNT }" > clones.json
+          COUNT=$(jq -r '.count // 0' traffic.json)
+          mkdir -p stats
+          echo "{ \"count\": ${COUNT} }" > stats/clones.json
 
       - name: Commit and push to stats branch
         run: |
-          git checkout -B stats
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
           git add stats/clones.json


### PR DESCRIPTION
### Motivation
- Make the clone statistics workflow repository-agnostic by removing a hardcoded repo name and ensure the stats branch exists before updates. 
- Improve robustness of the network fetch and JSON parsing so the action does not fail on missing values or silent curl errors.

### Description
- Add an early step to create/switch to the `stats` branch with `git checkout -B stats` before fetching or writing files. 
- Use a dynamic API endpoint with `"https://api.github.com/repos/${{ github.repository }}/traffic/clones"` instead of a hardcoded repository path. 
- Change `curl` to use `-sS` to surface errors and update `jq` parsing to `jq -r '.count // 0'` to default to `0` when the field is absent. 
- Create a `stats` directory, write `stats/clones.json`, and update `git add`/commit to include that path while removing the redundant checkout in the commit step. 

### Testing
- No automated tests were executed for this workflow file change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a645028278832b8a2e02a55e2be9a1)