### PR TITLE
Fix clone-stats workflow auth and publish total + unique clone counts

### DIFF
--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   update-clone-stats:
     runs-on: ubuntu-latest
+    env:
+      # Prefer a personal access token for traffic APIs. Fall back to GITHUB_TOKEN.
+      TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -23,17 +26,26 @@ jobs:
 
       - name: Fetch clone stats from GitHub API
         run: |
-          curl -sS \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          TOKEN="${TRAFFIC_TOKEN:-${{ github.token }}}"
+          curl -fsSL \
+            -H "Authorization: Bearer ${TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/traffic/clones" \
             -o traffic.json
 
-      - name: Extract total count
+          # Fail early with a clear message if GitHub API did not return usable traffic data.
+          if [ "$(jq -r 'has("count") and has("uniques")' traffic.json)" != "true" ]; then
+            echo "Failed to fetch clone traffic. Response:"
+            cat traffic.json
+            exit 1
+          fi
+
+      - name: Extract total clone stats
         run: |
           COUNT=$(jq '.count' traffic.json)
+          UNIQUES=$(jq '.uniques' traffic.json)
           mkdir -p stats
-          echo "{ \"count\": $COUNT }" > stats/clones.json
+          echo "{ \"count\": $COUNT, \"uniques\": $UNIQUES }" > stats/clones.json
 
       - name: Commit and push to stats branch
         run: |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <p><b>Centralize. Unify. Govern.</b></p>
 
 ![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
+![Unique cloners (14d)](https://img.shields.io/badge/dynamic/json?color=informational&label=Unique%20cloners%20(14d)&query=uniques&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
   [![CI develop](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v17&label=CI%20develop)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v16](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v16&label=CI%20v16)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v15](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v15&label=CI%20v15)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)

--- a/stats/README.md
+++ b/stats/README.md
@@ -6,3 +6,6 @@ This folder is used by the clone-stats GitHub Action.
 - The README badge reads that JSON from the `stats` branch.
 
 If you do not see recent data, trigger the **Update Clone Stats** workflow manually and wait for cache refresh.
+
+- If clone totals stay empty, add a `TRAFFIC_TOKEN` repository secret (classic PAT with `repo` scope) so the workflow can access the traffic API reliably.
+- `stats/clones.json` now stores both `count` (total clones in last 14 days) and `uniques` (unique cloners in last 14 days).


### PR DESCRIPTION
### Motivation
- The existing clone stats workflow sometimes produced empty badges because the default action token lacks access to the traffic API, and only `count` was published so unique cloners were not shown.
- Provide a reliable means to fetch GitHub traffic and expose both total clones and unique cloners for the last 14 days.

### Description
- Updated `.github/workflows/clone-stats.yml` to prefer a `TRAFFIC_TOKEN` repository secret (personal access token) with a fallback to the workflow `github.token` and to use `curl -fsSL` for robust fetching.
- Added early validation of the API response (`jq` check for `count` and `uniques`) and a clear failure message when traffic data is unavailable.
- Extended the generated `stats/clones.json` to include both `count` and `uniques` and updated `README.md` to add a new badge for `Unique cloners (14d)`.
- Documented the `TRAFFIC_TOKEN` recommendation and the new JSON fields in `stats/README.md`.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff problems and it succeeded.
- Committed the changes successfully with `git commit` which returned without errors.
- Attempted YAML validation with `python` + `yaml.safe_load` which failed because `PyYAML` is not installed in the environment, so full programmatic YAML validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64948c854832b8356ea4fd7d4727e)