### PR TITLE
Fix clone stats updater and README to use develop branch

### DIFF
--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -32,11 +32,10 @@ jobs:
           mkdir -p stats
           echo "{ \"count\": $COUNT }" > stats/clones.json
 
-      - name: Commit and push to stats branch
+      - name: Commit and push to develop branch
         run: |
-          git checkout -B stats
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
           git add stats/clones.json
           git commit -m "Update clone stats" || exit 0
-          git push origin stats --force
+          git push origin HEAD:develop

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   <p><b>Centralize. Unify. Govern.</b></p>
 
-![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
+![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/develop/stats/clones.json)
   [![CI develop](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v17&label=CI%20develop)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v16](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v16&label=CI%20v16)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v15](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v15&label=CI%20v15)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)

--- a/stats/README.md
+++ b/stats/README.md
@@ -2,7 +2,7 @@
 
 This folder is used by the clone-stats GitHub Action.
 
-- On the `stats` branch, the workflow writes `stats/clones.json` every run.
-- The README badge reads that JSON from the `stats` branch.
+- On the `develop` branch, the workflow writes `stats/clones.json` every run.
+- The root README badge reads that JSON from the `develop` branch.
 
 If you do not see recent data, trigger the **Update Clone Stats** workflow manually and wait for cache refresh.


### PR DESCRIPTION
### Motivation
- The clone-stats GitHub Action was writing `stats/clones.json` to a `stats` branch while the README badge was reading from the repository root, causing the badge not to reflect updated counts.
- Make the workflow and documentation consistent so the README badge can read the clone count JSON from a branch that is actually updated by the workflow.

### Description
- Change `.github/workflows/clone-stats.yml` to push the generated `stats/clones.json` to the `develop` branch by using `git push origin HEAD:develop` instead of updating a separate `stats` branch.
- Update the README badge in `README.md` to reference the JSON at `develop/stats/clones.json` so the badge reads the up-to-date clone count.
- Align `stats/README.md` text to document that `stats/clones.json` is written to the `develop` branch and that the root README badge reads from that location.

### Testing
- Ran `git diff -- .github/workflows/clone-stats.yml README.md stats/README.md` to verify the intended diffs were applied, which showed the expected changes (success).
- Ran `git status --short` and `git rev-parse --short HEAD` to inspect repository state and confirm the workspace had the updated files (success).
- Inspected file contents with `nl -ba`/file prints to ensure the workflow step, badge URL, and docs were updated as intended (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7458b27dc832bbf3e3c9d030eaee7)