### PR TITLE
Improve clone-stats workflow: token fallback, robust fetch, and write to develop branch

### DIFF
--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -19,24 +19,51 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch clone stats from GitHub API
+        env:
+          API_URL: https://api.github.com/repos/Sendipad/uph/traffic/clones
+          TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+          GITHUB_TOKEN_FALLBACK: ${{ github.token }}
         run: |
-          curl -s \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/Sendipad/uph/traffic/clones \
-            -o traffic.json
+          set -euo pipefail
+
+          fetch_traffic() {
+            local token="$1"
+            curl -sS \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/vnd.github+json" \
+              -o traffic.json \
+              -w "%{http_code}" \
+              "$API_URL"
+          }
+
+          if [ -n "${TRAFFIC_TOKEN}" ]; then
+            HTTP_CODE=$(fetch_traffic "${TRAFFIC_TOKEN}")
+            if [ "${HTTP_CODE}" = "401" ]; then
+              echo "TRAFFIC_TOKEN was rejected (401); retrying with github.token fallback."
+              HTTP_CODE=$(fetch_traffic "${GITHUB_TOKEN_FALLBACK}")
+            fi
+          else
+            echo "TRAFFIC_TOKEN is not set; using github.token fallback."
+            HTTP_CODE=$(fetch_traffic "${GITHUB_TOKEN_FALLBACK}")
+          fi
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Failed to fetch clone traffic (HTTP ${HTTP_CODE}). Response:"
+            cat traffic.json
+            echo "Hint: configure a repository secret TRAFFIC_TOKEN with a classic PAT that has 'repo' scope."
+            exit 1
+          fi
 
       - name: Extract total count
         run: |
-          COUNT=$(jq '.count' traffic.json)
+          COUNT=$(jq -er '.count' traffic.json)
           mkdir -p stats
           echo "{ \"count\": $COUNT }" > stats/clones.json
 
-      - name: Commit and push to stats branch
+      - name: Commit and push to develop branch
         run: |
-          git checkout -B stats
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
           git add stats/clones.json
           git commit -m "Update clone stats" || exit 0
-          git push origin stats --force
+          git push origin HEAD:develop

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   <p><b>Centralize. Unify. Govern.</b></p>
 
-![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
+![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/develop/stats/clones.json)
   [![CI develop](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v17&label=CI%20develop)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v16](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v16&label=CI%20v16)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v15](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v15&label=CI%20v15)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)

--- a/stats/README.md
+++ b/stats/README.md
@@ -2,7 +2,9 @@
 
 This folder is used by the clone-stats GitHub Action.
 
-- On the `stats` branch, the workflow writes `stats/clones.json` every run.
-- The README badge reads that JSON from the `stats` branch.
+- On the `develop` branch, the workflow writes `stats/clones.json` every run.
+- The root README badge reads that JSON from the `develop` branch.
 
 If you do not see recent data, trigger the **Update Clone Stats** workflow manually and wait for cache refresh.
+
+> Note: GitHub's traffic API often returns `403 Resource not accessible by integration` when called with the default `github.token`. Set a repository secret named `TRAFFIC_TOKEN` (classic PAT with `repo` scope) for reliable updates.


### PR DESCRIPTION
### Motivation

- Make the clone traffic updater more reliable by using a dedicated PAT when available and falling back to the built-in `github.token` otherwise.
- Fail fast and provide actionable error messages when the GitHub traffic API doesn't return a successful response.
- Centralize repository artifacts on the `develop` branch and update badges and docs to reference the new location.

### Description

- Updated the `.github/workflows/clone-stats.yml` workflow to accept `TRAFFIC_TOKEN` and `GITHUB_TOKEN_FALLBACK` environment variables and to use a `fetch_traffic` helper that captures HTTP status codes from `curl`.
- Added logic to prefer `TRAFFIC_TOKEN`, retry with `github.token` on `401`, and exit with a helpful message and hint when the fetch doesn't return `200`.
- Switched JSON extraction to use `jq -er` for stricter failure behavior and moved the pushed artifact from the `stats` branch to `develop` by pushing `HEAD:develop`.
- Updated `README.md` and `stats/README.md` to read `stats/clones.json` from the `develop` branch and added documentation advising to set a `TRAFFIC_TOKEN` (classic PAT with `repo` scope) due to API restrictions.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7458b27dc832bbf3e3c9d030eaee7)