### PR TITLE
Improve clone-stats workflow: token fallback, error handling, and write to develop branch; update README

### DIFF
--- a/.github/workflows/clone-stats.yml
+++ b/.github/workflows/clone-stats.yml
@@ -19,24 +19,61 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch clone stats from GitHub API
+        id: fetch_clone_stats
+        env:
+          API_URL: https://api.github.com/repos/Sendipad/uph/traffic/clones
+          TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+          GITHUB_TOKEN_FALLBACK: ${{ github.token }}
         run: |
-          curl -s \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/Sendipad/uph/traffic/clones \
-            -o traffic.json
+          set -euo pipefail
+
+          fetch_traffic() {
+            local token="$1"
+            curl -sS \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/vnd.github+json" \
+              -o traffic.json \
+              -w "%{http_code}" \
+              "$API_URL"
+          }
+
+          if [ -n "${TRAFFIC_TOKEN}" ]; then
+            HTTP_CODE=$(fetch_traffic "${TRAFFIC_TOKEN}")
+            if [ "${HTTP_CODE}" = "401" ]; then
+              echo "TRAFFIC_TOKEN was rejected (401); retrying with github.token fallback."
+              HTTP_CODE=$(fetch_traffic "${GITHUB_TOKEN_FALLBACK}")
+            fi
+          else
+            echo "TRAFFIC_TOKEN is not set; using github.token fallback."
+            HTTP_CODE=$(fetch_traffic "${GITHUB_TOKEN_FALLBACK}")
+          fi
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Unable to fetch clone traffic (HTTP ${HTTP_CODE}). Response:"
+            cat traffic.json
+            echo "Hint: configure a repository secret TRAFFIC_TOKEN with a classic PAT that has 'repo' scope."
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "success=true" >> "$GITHUB_OUTPUT"
 
       - name: Extract total count
+        if: steps.fetch_clone_stats.outputs.success == 'true'
         run: |
-          COUNT=$(jq '.count' traffic.json)
+          COUNT=$(jq -er '.count' traffic.json)
           mkdir -p stats
           echo "{ \"count\": $COUNT }" > stats/clones.json
 
-      - name: Commit and push to stats branch
+      - name: Skip update when traffic API is unavailable
+        if: steps.fetch_clone_stats.outputs.success != 'true'
+        run: echo "Skipping clone stats write/commit because traffic API was unavailable for this run."
+
+      - name: Commit and push to develop branch
+        if: steps.fetch_clone_stats.outputs.success == 'true'
         run: |
-          git checkout -B stats
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
           git add stats/clones.json
           git commit -m "Update clone stats" || exit 0
-          git push origin stats --force
+          git push origin HEAD:develop

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   <p><b>Centralize. Unify. Govern.</b></p>
 
-![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/stats/clones.json)
+![Clones (14d total)](https://img.shields.io/badge/dynamic/json?color=blue&label=Clones%20(14d%20total)&query=count&url=https://raw.githubusercontent.com/Sendipad/uph/develop/stats/clones.json)
   [![CI develop](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v17&label=CI%20develop)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v16](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v16&label=CI%20v16)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)
   [![CI v15](https://img.shields.io/github/actions/workflow/status/Sendipad/uph/ci.yml?branch=develop&job=test_v15&label=CI%20v15)](https://github.com/Sendipad/uph/actions/workflows/ci.yml)

--- a/stats/README.md
+++ b/stats/README.md
@@ -2,7 +2,9 @@
 
 This folder is used by the clone-stats GitHub Action.
 
-- On the `stats` branch, the workflow writes `stats/clones.json` every run.
-- The README badge reads that JSON from the `stats` branch.
+- On the `develop` branch, the workflow writes `stats/clones.json` every run.
+- The root README badge reads that JSON from the `develop` branch.
 
 If you do not see recent data, trigger the **Update Clone Stats** workflow manually and wait for cache refresh.
+
+> Note: GitHub's traffic API often returns `403 Resource not accessible by integration` when called with the default `github.token`. Set a repository secret named `TRAFFIC_TOKEN` (classic PAT with `repo` scope) for reliable updates. If the API is unavailable, the workflow now skips the update gracefully and keeps the previous clone count.


### PR DESCRIPTION
### Motivation

- Make the clone-stat collection more reliable when the default `github.token` is rejected by GitHub's traffic API.  
- Avoid failing the workflow on transient or permission errors and keep previous stats intact when the API is unavailable.  
- Consolidate generated `stats/clones.json` on the `develop` branch and update badges/docs to read from that branch.

### Description

- Add `TRAFFIC_TOKEN` environment variable and fallback to `github.token`, and implement a `fetch_traffic` helper that captures HTTP status to detect `401`/other errors.  
- Harden the shell steps with `set -euo pipefail`, use `jq -er` to extract the `.count` value, and set a `success` output to drive conditional step execution.  
- Skip the stats write when the traffic API is unavailable and change the workflow to update the `develop` branch (previously `stats`) for `stats/clones.json`.  
- Update `README.md` and `stats/README.md` to point the badges and documentation at `develop/stats/clones.json` and add guidance to configure a `TRAFFIC_TOKEN` (classic PAT with `repo` scope).

### Testing

- No automated unit tests were added or run as part of this change.  
- The workflow changes are limited to the GitHub Actions YAML and documentation, and will be exercised on the next scheduled/manual run by GitHub Actions.  
- Manual verification of the new control-flow paths is recommended by triggering the updated `Update Clone Stats` workflow after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7458b27dc832bbf3e3c9d030eaee7)