### PR TITLE
Fix Party Issue workflow actions and severity sorting

### DIFF
--- a/uph/party/controllers/party_issue_utils.py
+++ b/uph/party/controllers/party_issue_utils.py
@@ -5,6 +5,18 @@ from frappe.utils import now_datetime
 
 OPEN_STATUSES = ("Open", "Under Review")
 TERMINAL_STATUSES = ("Resolved", "Ignored")
+SEVERITY_RANK = {
+    "High": 4,
+    "Critical": 3,
+    "Medium": 2,
+    "Low": 1,
+}
+
+
+def get_severity_rank(severity: str | None) -> int:
+    if not severity:
+        return 0
+    return SEVERITY_RANK.get(severity, 0)
 
 
 def normalize_party_pair(party_1, party_2):
@@ -81,11 +93,15 @@ def create_party_issue_if_missing(
     new_details_json = (
         json.dumps(details) if isinstance(details, (dict, list)) else details
     )
+    new_severity_rank = get_severity_rank(severity)
 
     if existing_doc:
         updates = {}
         if existing_doc.severity != severity:
             updates["severity"] = severity
+            updates["severity_rank"] = new_severity_rank
+        elif getattr(existing_doc, "severity_rank", None) != new_severity_rank:
+            updates["severity_rank"] = new_severity_rank
         if score is not None and getattr(existing_doc, "score", None) != score:
             updates["score"] = score
         if existing_doc.details_json != new_details_json:
@@ -102,6 +118,7 @@ def create_party_issue_if_missing(
             "party_master": party_master,
             "issue_type": issue_type,
             "severity": severity,
+            "severity_rank": new_severity_rank,
             "status": status,
             "score": score,
             "reference_doctype": reference_doctype,

--- a/uph/party/controllers/transaction_health.py
+++ b/uph/party/controllers/transaction_health.py
@@ -16,7 +16,10 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, cint, now_datetime
 
-from uph.party.controllers.party_issue_utils import create_party_issue_if_missing
+from uph.party.controllers.party_issue_utils import (
+    create_party_issue_if_missing,
+    get_severity_rank,
+)
 from uph.party.controllers.cache_utils import (
     get_doctypes_functional_fields_mapping_as_dict,
 )
@@ -656,9 +659,15 @@ def sync_transaction_health_issues():
         else:
             # 3. If not resolved, sync severity
             current_severity = severity_map.get(dt, "High")
-            if issue.severity != current_severity:
+            current_rank = get_severity_rank(current_severity)
+            if (
+                issue.severity != current_severity
+                or getattr(issue, "severity_rank", None) != current_rank
+            ):
                 frappe.db.set_value(
-                    "Party Issue", issue.name, "severity", current_severity
+                    "Party Issue",
+                    issue.name,
+                    {"severity": current_severity, "severity_rank": current_rank},
                 )
                 updated_count += 1
 

--- a/uph/party/doctype/party_issue/party_issue.js
+++ b/uph/party/doctype/party_issue/party_issue.js
@@ -6,26 +6,82 @@ frappe.ui.form.on("Party Issue", {
     },
 
     setup_buttons(frm) {
-        if (frm.doc.status === "Open") {
-            frm.add_custom_button(__("Resolve"), () => {
-                frm.set_value("status", "Resolved");
-                frm.save();
-            }, __("Actions"));
+        const apply_workflow_action = (action, reason = null) => {
+            frappe.dom.freeze();
+            const maybe_set_reason = reason
+                ? frm.set_value("dismiss_reason", reason)
+                : Promise.resolve();
 
-            frm.add_custom_button(__("Ignore"), () => {
-                frappe.prompt([
-                    {
-                        label: __("Reason for Ignoring"),
-                        fieldname: "reason",
-                        fieldtype: "Small Text",
-                        reqd: 1
+            maybe_set_reason
+                .then(() =>
+                    frappe.xcall("frappe.model.workflow.apply_workflow", {
+                        doc: frm.doc,
+                        action: action,
+                    })
+                )
+                .then((doc) => {
+                    if (doc) {
+                        frappe.model.sync(doc);
                     }
-                ], (values) => {
-                    frm.set_value("status", "Ignored");
-                    frm.set_value("dismiss_reason", values.reason);
-                    frm.save();
-                }, __("Ignore Issue"), __("Submit"));
-            }, __("Actions"));
+                    frm.refresh();
+                })
+                .finally(() => {
+                    frappe.dom.unfreeze();
+                });
+        };
+
+        if (frm.doc.status === "Open") {
+            frm.add_custom_button(
+                __("Review"),
+                () => apply_workflow_action("Review"),
+                __("Actions")
+            );
+        }
+
+        if (frm.doc.status === "Under Review") {
+            frm.add_custom_button(
+                __("Resolve"),
+                () => {
+                    frappe.prompt(
+                        [
+                            {
+                                label: __("Reason"),
+                                fieldname: "reason",
+                                fieldtype: "Small Text",
+                                reqd: 1,
+                            },
+                        ],
+                        (values) => {
+                            apply_workflow_action("Resolve", values.reason);
+                        },
+                        __("Resolve Issue"),
+                        __("Submit")
+                    );
+                },
+                __("Actions")
+            );
+
+            frm.add_custom_button(
+                __("Ignore"),
+                () => {
+                    frappe.prompt(
+                        [
+                            {
+                                label: __("Reason"),
+                                fieldname: "reason",
+                                fieldtype: "Small Text",
+                                reqd: 1,
+                            },
+                        ],
+                        (values) => {
+                            apply_workflow_action("Ignore", values.reason);
+                        },
+                        __("Ignore Issue"),
+                        __("Submit")
+                    );
+                },
+                __("Actions")
+            );
         }
     },
 

--- a/uph/party/doctype/party_issue/party_issue.json
+++ b/uph/party/doctype/party_issue/party_issue.json
@@ -9,6 +9,7 @@
   "details_section",
   "issue_type",
   "severity",
+  "severity_rank",
   "status",
   "column_break_core",
   "party_master",
@@ -52,6 +53,13 @@
    "search_index": 1
   },
   {
+   "fieldname": "severity_rank",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Severity Rank",
+   "read_only": 1
+  },
+  {
    "default": "Open",
    "fieldname": "status",
    "fieldtype": "Select",
@@ -73,8 +81,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Party Master",
+   "mandatory_depends_on": "eval:doc.issue_type!='Unlinked'",
    "options": "Party Master",
-   "reqd": 1,
    "search_index": 1
   },
   {
@@ -151,11 +159,12 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.status=='Ignored'",
-   "description": "Reason of Ignoring",
+   "depends_on": "eval:doc.status=='Ignored' || doc.status=='Resolved'",
+   "description": "Reason of Ignoring or Resolving",
    "fieldname": "dismiss_reason",
    "fieldtype": "Small Text",
-   "label": "Dismiss Reason"
+   "label": "Dismiss Reason",
+   "mandatory_depends_on": "eval:doc.status=='Ignored' || doc.status=='Resolved'"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -191,7 +200,7 @@
   }
  ],
  "row_format": "Dynamic",
- "sort_field": "severity",
+ "sort_field": "severity_rank",
  "sort_order": "DESC",
  "states": []
 }

--- a/uph/party/doctype/party_issue/party_issue.py
+++ b/uph/party/doctype/party_issue/party_issue.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from uph.party.controllers.party_issue_utils import get_severity_rank
 
 class PartyIssue(Document):
     # begin: auto-generated types
@@ -26,6 +27,7 @@ class PartyIssue(Document):
         resolved_on: DF.Datetime | None
         score: DF.Float
         severity: DF.Literal["Low", "Medium", "High", "Critical"]
+        severity_rank: DF.Int
         source_engine: DF.Data | None
         status: DF.Literal["Open", "Under Review", "Resolved", "Ignored"]
     # end: auto-generated types
@@ -34,6 +36,7 @@ class PartyIssue(Document):
             self.detected_on = frappe.utils.now_datetime()
 
     def validate(self):
+        self.severity_rank = get_severity_rank(self.severity)
         self._set_resolution_metadata()
 
     def _set_resolution_metadata(self):
@@ -61,5 +64,31 @@ def on_doctype_update():
 
     # 3. Dashboard/Priority index
     frappe.db.add_index(
-        "Party Issue", ["status", "severity", "detected_on"], "idx_dashboard_order"
+        "Party Issue", ["status", "severity_rank", "detected_on"], "idx_dashboard_order"
     )
+
+    # Backfill severity_rank for existing records (safe, idempotent)
+    start = 0
+    page_len = 500
+    while True:
+        rows = frappe.get_all(
+            "Party Issue",
+            fields=["name", "severity"],
+            or_filters=[
+                ["severity_rank", "is", "not set"],
+                ["severity_rank", "=", 0],
+            ],
+            limit_start=start,
+            limit_page_length=page_len,
+        )
+        if not rows:
+            break
+        for row in rows:
+            frappe.db.set_value(
+                "Party Issue",
+                row.name,
+                "severity_rank",
+                get_severity_rank(row.severity),
+                update_modified=False,
+            )
+        start += page_len

--- a/uph/party/doctype/party_issue/party_issue_list.js
+++ b/uph/party/doctype/party_issue/party_issue_list.js
@@ -1,4 +1,6 @@
 frappe.listview_settings['Party Issue'] = {
+    sort_by: "severity_rank",
+    sort_order: "desc",
     hide_name_column: true,
     get_indicator(doc) {
         const status_colors = {

--- a/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
+++ b/uph/party/page/data_quality_dashboard/data_quality_dashboard.js
@@ -108,8 +108,9 @@ class DataQualityDashboard {
             frappe.call({
                 method: 'uph.party.page.data_quality_dashboard.data_quality_dashboard.run_all_scans',
                 callback: (r) => {
-                    if (r.message) {
-                        frappe.show_alert({ message: r.message, indicator: 'blue' });
+                    const message = (r && r.message && r.message.message) || (r && r.message);
+                    if (message) {
+                        frappe.show_alert({ message, indicator: 'blue' });
                     }
                     this.load_stats();
                     this.load_tab_content();


### PR DESCRIPTION
Summary:\n- Align Party Issue form actions with workflow transitions\n- Require reason on resolve/ignore\n- Add severity_rank for stable sorting without SQL functions\n- Update list view to sort by severity_rank\n\nNotes:\n- Backfills severity_rank on doctype update\n- Adjusts transaction health severity sync\n